### PR TITLE
feat: add csv_attachment component

### DIFF
--- a/examples/todo application (PostgreSQL)/csv_attachment.sql
+++ b/examples/todo application (PostgreSQL)/csv_attachment.sql
@@ -1,0 +1,6 @@
+select 
+    'csv_attachment' as component, 
+    ';' as separator, 
+    'todo.csv' as filename;
+
+select * from todos;

--- a/examples/todo application (PostgreSQL)/index.sql
+++ b/examples/todo application (PostgreSQL)/index.sql
@@ -18,3 +18,7 @@ select
     'green' as color,
     'Add new todo'  as title,
     'circle-plus'  as icon;
+select 
+    '/csv_attachment.sql' as link,
+    'Download'  as title,
+    'download' as icon;

--- a/sqlpage/templates/csv_attachment.handlebars
+++ b/sqlpage/templates/csv_attachment.handlebars
@@ -1,0 +1,6 @@
+{{#each_row}}
+{{#if (eq @row_index 0)}}
+{{#each this}}{{@key}}{{#unless @last}}{{default ../../separator ","}}{{/unless}}{{/each}}{{../linebreak}}
+{{/if}}
+{{#each this}}{{this}}{{#unless @last}}{{default ../../separator ","}}{{/unless}}{{/each}}{{../linebreak}}
+{{/each_row}}

--- a/src/render.rs
+++ b/src/render.rs
@@ -202,7 +202,7 @@ impl<'a, W: std::io::Write> HeaderContext<W> {
         Ok(self.response.body(json_response))
     }
 
-    async fn csv_attachment(mut self, data: JsonValue) ->  anyhow::Result<PageContext<W>> {
+    async fn csv_attachment(mut self, data: JsonValue) -> anyhow::Result<PageContext<W>> {
         let filename = data
             .get("filename")
             .and_then(JsonValue::as_str)
@@ -214,7 +214,7 @@ impl<'a, W: std::io::Write> HeaderContext<W> {
                 header::CONTENT_DISPOSITION,
                 format!("attachment; filename=\"{}\"", filename),
             ));
-        
+
         self.request_context.is_embedded = true;
         let page_content = self.start_body(data).await?;
 


### PR DESCRIPTION
Hi 👋,

This commit follows the discussion in [#260](https://github.com/lovasoa/SQLpage/discussions/260) (better late than never!). It implements the `csv_attachment` component to return data as a CSV file.

```sql
SELECT 
    'csv_attachment' AS component, 
    ';' AS separator, 
    'todo.csv' AS filename;
SELECT * FROM todos;
```
It works, but it feels a bit hacky due to the use of `is_embedded` and Handlebars. Please feel free to make any changes, rename the component, or point me in the right direction.

If you like this implementation, I can add the component to the documentation.
