### PR TITLE
Improve CSS for SQL code printer-friendly display (eg. print ALL code)

### DIFF
--- a/sqlpage/sqlpage.css
+++ b/sqlpage/sqlpage.css
@@ -1,6 +1,13 @@
 /* !include https://cdn.jsdelivr.net/npm/@tabler/core@1.0.0-beta20/dist/css/tabler.min.css */
 /* !include https://cdn.jsdelivr.net/npm/@tabler/core@1.0.0-beta20/dist/css/tabler-vendors.min.css */
 
+/* 241220RH printer-friendly; output all code to the printer */
+@media print {
+    pre:has(code) {
+        max-height: none !important;
+    }
+}
+
 :root {
   /* Workaround for https://github.com/tabler/tabler/issues/1879 */
   --tblr-text-secondary-rgb: var(--tblr-secondary-rgb);


### PR DESCRIPTION
# Fix Print Layout for Code Blocks with max-height

## Problem
When printing a page containing a `<code>` element with a large amount of data and a defined `max-height`, only a portion of the code is visible in the printed output. The scrollbar that appears on screen is not useful in printed format, resulting in incomplete code printouts.

## Solution
Modified the CSS to ensure that code blocks display their complete content when printing, regardless of their `max-height` setting on screen. This was achieved by adjusting the print media query in sqlpage.css.

## Changes Made
- Added print-specific CSS rules to override `max-height` restrictions during printing
- Ensured code blocks expand to show all content in print layout
- Maintained existing screen display behavior

## Testing Instructions
1. Create a SQL page with a large code block (more than would fit in the default max-height)
2. View the print preview (Ctrl+P in most browsers)
3. Verify that:
   - All code content is visible in the print preview
   - No content is cut off
   - No scrollbars appear in the print version

## Additional Notes
- This change only affects the print layout and does not modify the on-screen display
- The solution maintains the original responsive design principles
- No breaking changes to existing functionality

---
By improving the print layout, this change makes SQLPage more useful for documentation and sharing purposes, as users can now reliably print complete code blocks.
