### PR TITLE
Added an option to format numbers using `toLocaleString()` for table columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@
 - Add a new `auto_submit` parameter to the form component. When set to true, the form will be automatically submitted when the user changes any of its fields, and the page will be reloaded with the new value. The validation button is removed.
   - This is useful to quickly create filters at the top of a dashboard or report page, that will be automatically applied when the user changes them.
 - New `options_source` parameter in the form component. This allows to dynamically load options for dropdowns from a different SQL file.
- - This allows easily implementing autocomplete for form fields with a large number of possible options.
- - In the map component, add support for map pins with a description but no title.
+  - This allows easily implementing autocomplete for form fields with a large number of possible options.
+- In the map component, add support for map pins with a description but no title.
 - Improved error messages when a parameter of a sqlpage function is invalid. Error traces used to be truncated, and made it hard to understand the exact cause of the error in some cases. In particular, calls to `sqlpage.fetch` would display an unhelpful error message when the HTTP request definition was invalid. `sqlpage.fetch` now also throws an error if the HTTP request definition contains unknown fields.
 - Make the `headers` field of the `sqlpage.fetch` function parameter optional. It defaults to sending a User-Agent header containing the SQLPage version.
 - Make custom layout creations with the `card` component easier and less error-prone:
@@ -23,6 +23,16 @@
   - When an embedded page is rendered, the `shell` component is automatically replaced by a `shell-empty` component, to avoid displaying a duplicate shell and creating invalid duplicated page metadata in the response.
 - Update Tabler Icons to version [3.30.0](https://tabler.io/changelog#/changelog/tabler-icons-3.30), with many new icons.
 - Update the CSS framework to [Tabler 1.0.0](https://github.com/tabler/tabler/releases/tag/v1.0.0), with many small UI consistency improvements.
+- Add native number formatting to the table component. Numeric values in tables are now formatted in the visitor's locale by default, using country-specific thousands separators and decimal points.
+  - This is better than formatting numbers inside the database, because 
+    - columns are sorted correctly in the numeric order by default, instead of being sorted in the alphabetic order of the formatted string.
+    - the formatted numbers are more readable for the user by default, without requiring any additional code.
+    - it adapts to the visitor's preferred locale, for instance using `.` as a decimal point and a space as a thousands separator if the visitor is in France.
+    - less data is sent from the database to sqlpage, and from sqlpage to the client, because the numbers are not formatted directly in the database.
+  - Add new customization properties to the table component:
+    - Switch back to displaying raw numbers without formatting using the `raw_numbers` property.
+    - Format monetary values using the `money` property to specify columns and `currency` to set the currency.
+    - Control decimal places with `number_format_digits` property.
 
 ## 0.32.1 (2025-01-03)
 
@@ -118,7 +128,7 @@ This is a bugfix release.
     - Added support for:
       - advanced `JSON_TABLE` usage in MySQL for working with JSON arrays.
       - `EXECUTE` statements with parameters in MSSQL for running stored procedures.
-      - MSSQL’s `TRY_CONVERT` function for type conversion.
+      - MSSQL's `TRY_CONVERT` function for type conversion.
       - `ANY`, `ALL`, and `SOME` subqueries (e.g., `SELECT * FROM t WHERE a = ANY (SELECT b FROM t2)`).
       - `LIMIT max_rows, offset` syntax in SQLite.
       - Assigning column names aliases using `=` in MSSQL (e.g., `SELECT col_name = value`).

--- a/examples/official-site/sqlpage/migrations/01_documentation.sql
+++ b/examples/official-site/sqlpage/migrations/01_documentation.sql
@@ -780,10 +780,14 @@ INSERT INTO parameter(component, name, description, type, top_level, optional) S
     ('border', 'Whether to draw borders on all sides of the table and cells.', 'BOOLEAN', TRUE, TRUE),
     ('overflow', 'Whether to to let "wide" tables overflow across the right border and enable browser-based horizontal scrolling.', 'BOOLEAN', TRUE, TRUE),
     ('small', 'Whether to use compact table.', 'BOOLEAN', TRUE, TRUE),
-    ('description','Description of the table content and helps users with screen readers to find a table and understand what it’s.','TEXT',TRUE,TRUE),
+    ('description','Description of the table contents. Helps users with screen readers to find a table and understand what it’s about.','TEXT',TRUE,TRUE),
     ('empty_description', 'Text to display if the table does not contain any row. Defaults to "no data".', 'TEXT', TRUE, TRUE),
     ('freeze_columns', 'Whether to freeze the leftmost column of the table.', 'BOOLEAN', TRUE, TRUE),
     ('freeze_headers', 'Whether to freeze the top row of the table.', 'BOOLEAN', TRUE, TRUE),
+    ('raw_numbers', 'Name of a column whose values are numeric, but should be displayed as raw numbers without any formatting (no thousands separators, decimal separator is always a dot). This argument can be repeated multiple times.', 'TEXT', TRUE, TRUE),
+    ('money', 'Name of a numeric column whose values should be displayed as currency amounts, in the currency defined by the `currency` property. This argument can be repeated multiple times.', 'TEXT', TRUE, TRUE),
+    ('currency', 'The ISO 4217 currency code (e.g., USD, EUR, GBP, etc.) to use when formatting monetary values.', 'TEXT', TRUE, TRUE),
+    ('number_format_digits', 'Maximum number of decimal digits to display for numeric values.', 'INTEGER', TRUE, TRUE),
     -- row level
     ('_sqlpage_css_class', 'For advanced users. Sets a css class on the table row. Added in v0.8.0.', 'TEXT', FALSE, TRUE),
     ('_sqlpage_color', 'Sets the background color of the row. Added in v0.8.0.', 'COLOR', FALSE, TRUE),
@@ -804,12 +808,18 @@ INSERT INTO example(component, description, properties) VALUES
         ]')),
     (
     'table',
-    'A table with column sorting. Sorting sorts numbers in numeric order, and strings in alphabetical order.',
+    'A table with column sorting. Sorting sorts numbers in numeric order, and strings in alphabetical order.
+
+Numbers can be displayed 
+ - as raw digits without formatting using the `raw_numbers` property,
+ - as currency using the `money` property to define columns that contain monetary values and `currency` to define the currency,
+ - as numbers with a fixed maximum number of decimal digits using the `number_format_digits` property.
+',
     json(
-        '[{"component":"table", "sort": true, "align_right": ["Price ($)", "Amount in stock"], "align_center": ["part_no"] },
-         {"id": 31456, "part_no": "SQL-TABLE-856-G", "Price ($)": 12, "Amount in stock": 5},
-          {"id": 996, "part_no": "SQL-FORMS-86-M", "Price ($)": 1, "Amount in stock": 15},
-          {"id": 131456, "part_no": "SQL-CARDS-56-K", "Price ($)": 127, "Amount in stock": 9}
+        '[{"component":"table", "sort": true, "align_right": ["Price", "Amount in stock"], "align_center": ["part_no"], "raw_numbers": ["id"], "currency": "USD", "money": ["Price"] },
+         {"id": 31456, "part_no": "SQL-TABLE-856-G", "Price": 12, "Amount in stock": 5},
+          {"id": 996, "part_no": "SQL-FORMS-86-M", "Price": 1, "Amount in stock": 1234},
+          {"id": 131456, "part_no": "SQL-CARDS-56-K", "Price": 127, "Amount in stock": 98}
         ]'
     )),
     (

--- a/sqlpage/sqlpage.js
+++ b/sqlpage/sqlpage.js
@@ -35,7 +35,22 @@ function table_search_sort(el) {
       el,
       sort_keys: sort_buttons.map((b, idx) => {
         const sort_key = cells[idx]?.textContent;
-        return { num: Number.parseFloat(sort_key), str: sort_key };
+        const num = Number.parseFloat(sort_key);
+        // if the user requested for this column to be formatted using `toLocaleString()`,
+        // we replace the cell contents
+        if (cells[idx]?.hasAttribute("number-format-locale") && !Number.isNaN(num)) {
+          const digits = cell.getAttribute("number-format-digits");
+          // The variable `digits` can be left empty or contain an integer
+          const options = digits
+            ? { minimumFractionDigits: digits, maximumFractionDigits: digits }
+            : {};
+          // Use the host default language, with the options we just defined
+          cell.innerHTML = num.toLocaleString(undefined, options);
+        }
+        return {
+          num,
+          str: sort_key,
+        };
       }),
     };
   });

--- a/sqlpage/templates/table.handlebars
+++ b/sqlpage/templates/table.handlebars
@@ -21,7 +21,11 @@
             {{~#if hover}} table-hover {{/if~}}
             {{~#if border}} table-bordered {{/if~}}
             {{~#if small}} table-sm {{/if~}}
-            ">
+            "
+            {{~#if number_format_locale}} data-number_format_locale="{{number_format_locale}}"{{/if~}}
+            {{~#if number_format_digits}} data-number_format_digits="{{number_format_digits}}"{{/if~}}
+            {{~#if currency}} data-currency="{{currency}}"{{/if~}}
+            >
             {{#if description}}<caption>{{description}}</caption>{{/if}}
                 {{#each_row}}
                     {{#if (eq @row_index 0)}}
@@ -33,7 +37,11 @@
                                     {{~@key~}}
                                     {{~#if (array_contains_case_insensitive ../../align_right @key)}} text-end {{/if~}}
                                     {{~#if (array_contains_case_insensitive ../../align_center @key)}} text-center {{/if~}}
-                                ">
+                                "
+                                    data-column_type="{{typeof this}}"
+                                    {{~#if (array_contains_case_insensitive ../../raw_numbers @key)~}} data-raw_number="1"{{/if~}}
+                                    {{~#if (array_contains_case_insensitive ../../money @key)~}} data-money="1"{{/if~}}
+                                >
                                     {{~#if ../../sort~}}
                                         <button class="table-sort sort d-inline" data-sort="{{@key}}">{{@key}}</button>
                                     {{~else~}}
@@ -53,10 +61,7 @@
                             <td class="align-middle {{@key~}}
                                 {{~#if (array_contains_case_insensitive ../../align_right @key)}} text-end {{/if~}}
                                 {{~#if (array_contains_case_insensitive ../../align_center @key)}} text-center {{/if~}}
-                            "
-                                {{~#if (array_contains_case_insensitive ../../number_format_locale @key)}} number-format-locale {{/if~}}
-                                number-format-digits={{ ../../number_format_digits }}
-                            >
+                            ">
                                 {{~#if (array_contains_case_insensitive ../../markdown @key)~}}
                                     {{{markdown this}}}
                                 {{~else~}}

--- a/sqlpage/templates/table.handlebars
+++ b/sqlpage/templates/table.handlebars
@@ -53,7 +53,10 @@
                             <td class="align-middle {{@key~}}
                                 {{~#if (array_contains_case_insensitive ../../align_right @key)}} text-end {{/if~}}
                                 {{~#if (array_contains_case_insensitive ../../align_center @key)}} text-center {{/if~}}
-                            ">
+                            "
+                                {{~#if (array_contains_case_insensitive ../../number_format_locale @key)}} number-format-locale {{/if~}}
+                                number-format-digits={{ ../../number_format_digits }}
+                            >
                                 {{~#if (array_contains_case_insensitive ../../markdown @key)~}}
                                     {{{markdown this}}}
                                 {{~else~}}

--- a/tests/end-to-end/official-site.spec.ts
+++ b/tests/end-to-end/official-site.spec.ts
@@ -121,7 +121,9 @@ test("table sorting", async ({ page }) => {
   // Test amount in stock column sorting
   await tableSection.getByRole("button", { name: "Amount in stock" }).click();
   const amounts = await tableSection.locator("td.Amount").allInnerTexts();
-  const numericAmounts = amounts.map((amount) => Number.parseInt(amount));
+  const numericAmounts = amounts.map((amount) =>
+    Number.parseInt(amount.replace(/[^0-9]/g, "")),
+  );
   const sortedAmounts = [...numericAmounts].sort((a, b) => a - b);
   expect(numericAmounts).toEqual(sortedAmounts);
 });

--- a/tests/end-to-end/package-lock.json
+++ b/tests/end-to-end/package-lock.json
@@ -14,13 +14,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.49.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.49.1.tgz",
-      "integrity": "sha512-Ky+BVzPz8pL6PQxHqNRW1k3mIyv933LML7HktS8uik0bUXNCdPhoS/kLihiO1tMf/egaJb4IutXd7UywvXEW+g==",
+      "version": "1.50.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.50.1.tgz",
+      "integrity": "sha512-Jii3aBg+CEDpgnuDxEp/h7BimHcUTDlpEtce89xEumlJ5ef2hqepZ+PWp1DDpYC/VO9fmWVI1IlEaoI5fK9FXQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.49.1"
+        "playwright": "1.50.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -30,9 +30,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.10.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.5.tgz",
-      "integrity": "sha512-F8Q+SeGimwOo86fiovQh8qiXfFEh2/ocYv7tU5pJ3EXMSSxk1Joj5wefpFK2fHTf/N6HKGSxIDBT9f3gCxXPkQ==",
+      "version": "22.13.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.1.tgz",
+      "integrity": "sha512-jK8uzQlrvXqEU91UxiK5J7pKHyzgnI1Qnl0QDHIgVGuolJhRb9EEl28Cj9b3rGR8B2lhFCtvIm5os8lFnO/1Ew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -55,13 +55,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.49.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.1.tgz",
-      "integrity": "sha512-VYL8zLoNTBxVOrJBbDuRgDWa3i+mfQgDTrL8Ah9QXZ7ax4Dsj0MSq5bYgytRnDVVe+njoKnfsYkH3HzqVj5UZA==",
+      "version": "1.50.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.50.1.tgz",
+      "integrity": "sha512-G8rwsOQJ63XG6BbKj2w5rHeavFjy5zynBA9zsJMMtBoe/Uf757oG12NXz6e6OirF7RCrTVAKFXbLmn1RbL7Qaw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.49.1"
+        "playwright-core": "1.50.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -74,9 +74,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.49.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.1.tgz",
-      "integrity": "sha512-BzmpVcs4kE2CH15rWfzpjzVGhWERJfmnXmniSyKeRZUs9Ws65m+RGIi7mjJK/euCegfn3i7jvqWeWyHe9y3Vgg==",
+      "version": "1.50.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.50.1.tgz",
+      "integrity": "sha512-ra9fsNWayuYumt+NiM069M6OkcRb1FZSK8bgi66AtpFoWkg2+y0bJSNmkFrWhMbEBbVKC/EruAHH3g0zmtwGmQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {


### PR DESCRIPTION
Related to #802

This is the best I could hack, with my limited knowledge and in the time I had to spare. The basic usage is as follows:
- to select which columns should have their numbers formatted according to user locale, you specify them just like you would do for markdown
- there is an extra option that allows you to choose the exact number of decimal digits to be used when formatting, if you need such a precision. This is used for the entire table.

E.G: if you need a table with two columns with numbers formatted using exactly three decimals, and a markdown column with links, you would write
```
select 'table' as component,
    'links'  as markdown,
    'col A' as number_format_locale,
    'col B' as number_format_locale,
    3 as number_format_digits,
    TRUE as sort;
```

**Pros:**
- The changes are very much contained and easy to understand, I do not expect any interference with other features
- Functionality is limited, but can still be useful!

**Cons:**
- *Very* limited functionality. `toLocaleString()` can do so much more, and the list of available options is very very long. I am not sure if we should just allow the user to pass in a JSON structure so that he can choose whatever combination is needed (e.g: this can include formatting with a given currency!)
- no checks w.r.t. the input provided to the `number_format_digits` field, I have not tested to see what happens if a user inputs anything other than an integer
- when this feature is used, the whole table cell contents are replaced. In 99% of cases this should not be a problem, but I could see someone requesting a way to only format the number and keep the rest of the contents (e.g: keep a currency symbol after the number).

Let me know what you think about this!