### PR TITLE
Option to completely hide the footer from the shell.handlebars template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   - `markdown_allow_dangerous_html`: allow the usage of html in markdown (default: false)
   - `markdown_allow_dangerous_protocol`: allow the usage of custom protocols in markdown (default: false)
   - see [configuration.md](./configuration.md) for more details.
+- In the shell component, setting the `footer` parameter to the empty string (`''`) will now completely hide the footer, instead of showing the default one 
 
 ## 0.33.1 (2025-02-25)
 

--- a/sqlpage/templates/shell.handlebars
+++ b/sqlpage/templates/shell.handlebars
@@ -214,15 +214,17 @@
                 {{~#each_row~}}{{~/each_row~}}
             </main>
 
-            <footer class="w-100 text-center fs-6 my-2 text-secondary" id="sqlpage_footer">
-                {{#if footer}}
-                    {{{markdown footer}}}
-            {{else}}
-                <!-- You can change this footer using the 'footer' parameter of the 'shell' component -->
-                Built with <a class="text-reset" href="https://sql-page.com"
-                    title="SQLPage v{{buildinfo 'CARGO_PKG_VERSION'}}">SQLPage</a>
-            {{/if}}
-            </footer>
+            {{#unless (eq footer '')}}
+                <footer class="w-100 text-center fs-6 my-2 text-secondary" id="sqlpage_footer">
+                    {{#if footer}}
+                        {{{markdown footer}}}
+                    {{else}}
+                        <!-- You can change this footer using the 'footer' parameter of the 'shell' component -->
+                        Built with <a class="text-reset" href="https://sql-page.com"
+                            title="SQLPage v{{buildinfo 'CARGO_PKG_VERSION'}}">SQLPage</a>
+                    {{/if}}
+                </footer>
+            {{/unless}}
         </div>
     </div>
 </body>


### PR DESCRIPTION
By default handlebars handles all falsy values in the same way. This means that there is no way to easily remove the footer from the shell component, because no matter if you leave it empty or give it a `false` value, the default "Built with SQLPage" one appears.

With this small change, setting the value of the `footer` parameter to the empty string will completely hide the footer. As an example, this is the configuration from the `shell.json` in my project:
```
{
    "component": "shell",
    "footer": "",
    "title": "AA BB CC",
    "javascript": "/scripts/htmx.min.js",
    "link": "/",
    "menu_item": [
        {"link": "p1", "title": "Page 1"},
        {"link": "p2", "title": "Page 2"}
    ]
}

```