### PR TITLE
Revert sqlpage.json

### DIFF
--- a/sqlpage/sqlpage.json
+++ b/sqlpage/sqlpage.json
@@ -1,3 +1,3 @@
 {
-  "database_url": "sqlite:///tmp/bug.db?mode=rwc"
+  "database_url": "sqlite://./sqlpage/sqlpage.db?mode=rwc"
 }


### PR DESCRIPTION
With the actual sqlpage.json file, if you start SQLPage without knowing or noticing the connection string, an error appears:
[2025-03-17T10:58:01.236Z WARN  sqlpage::webserver::database::connect] Failed to connect to the database: error returned from database: (code: 14) unable to open database file. Retrying in 5 seconds.  

Because the specified path.