### PR TITLE
Add link & target props to big_number.handlebars

### DIFF
--- a/sqlpage/templates/big_number.handlebars
+++ b/sqlpage/templates/big_number.handlebars
@@ -10,9 +10,22 @@
   >
     <div class="card flex-fill {{#if color}}bg-{{color}}-lt{{/if}}">
       <div class="card-body d-flex flex-column">
+        
         {{#if title}}
         <div class="d-flex align-items-center">
-          <div class="subheader text-truncate me-2">{{title}}</div>
+          <!-- Otsikko (title): mahdollisuus linkkiin ja targetiin -->
+          <div class="subheader text-truncate me-2">
+            {{#if title_link}}
+              <a href="{{title_link}}" 
+                 class="text-decoration-none"
+                 {{#if title_target}} target="{{title_target}}" rel="noopener noreferrer" {{/if}}>
+                {{title}}
+              </a>
+            {{else}}
+              {{title}}
+            {{/if}}
+          </div>
+          
           {{#if dropdown_item}}
           <div class="ms-auto lh-1">
             <div class="dropdown">
@@ -31,8 +44,21 @@
           {{/if}}
         </div>
         {{/if~}}
+        
         <div class="d-flex align-items-center mt-1">
-          <div class="h1 {{#if description}}mb-3{{else}}mb-0{{/if}} mt-auto text-nowrap text-truncate">{{value}}{{#if unit}} {{unit}}{{/if}}</div>
+          <!-- Arvo (value): mahdollisuus linkkiin ja targetiin -->
+          <div class="h1 {{#if description}}mb-3{{else}}mb-0{{/if}} mt-auto text-nowrap text-truncate">
+            {{#if value_link}}
+              <a href="{{value_link}}"
+                 class="text-decoration-none"
+                 {{#if value_target}} target="{{value_target}}" rel="noopener noreferrer" {{/if}}>
+                {{value}}{{#if unit}} {{unit}}{{/if}}
+              </a>
+            {{else}}
+              {{value}}{{#if unit}} {{unit}}{{/if}}
+            {{/if}}
+          </div>
+          
           {{#if (and change_percent (not description))}}
           <div class="ms-auto">
             {{#if change_percent}}
@@ -48,6 +74,7 @@
           </div>
           {{/if}}
         </div>
+        
         {{~#if description}}
         <div class="d-flex flex-wrap mb-2" title="{{description}}">
           <div class="text-truncate me-2">{{description}}</div>
@@ -65,6 +92,7 @@
           {{~/if~}}
         </div>
         {{~/if~}}
+        
         {{~#if progress_percent~}}
         <div class="progress progress-sm">
           <div class="progress-bar bg-{{progress_color}}" style="width: {{progress_percent}}%" role="progressbar" aria-valuenow="{{progress_percent}}" aria-valuemin="0" aria-valuemax="100" aria-label="{{progress_percent}}% Complete">
@@ -72,6 +100,7 @@
           </div>
         </div>
         {{~/if}}
+        
       </div>
     </div>
   </div>


### PR DESCRIPTION
**We needed link functionality for the Big Number component**

This PR introduces support for adding links to both the title and the value fields in the Big Number component. It also allows specifying whether those links should open in the same tab (_self) or a new tab (_blank). The goal is to enable more interactive dashboards where users can navigate between pages directly by clicking on a Big Number’s text.
Usage

Added four optional properties:

    title_link (string): the URL or path that the Big Number’s title should link to, if any
    title_target (string): how the title link is opened, e.g. "_self" for same tab, or "_blank" for a new tab
    value_link (string): the URL or path that the Big Number’s value should link to, if any
    value_target (string): how the value link is opened, e.g. "_self" or "_blank"

`-- adding link + target properties for both title and value.

SELECT 
    'big_number'    AS component,
    'Weekly Stats'  AS title,
    '/stats_page.sql' AS title_link,   -- Link for the title
    '_blank'        AS title_target,   -- Opens in new tab
    42              AS value,
    '/details.sql'  AS value_link,     -- Link for the value
    '_self'         AS value_target,   -- Opens in same tab
    'green'         AS color,
    'Check out stats' AS description;
`