### PR TITLE
Added active indicator to nav-items

### DIFF
--- a/sqlpage/templates/shell.handlebars
+++ b/sqlpage/templates/shell.handlebars
@@ -94,7 +94,7 @@
             {{~#if (or (eq (typeof this) 'object') (and (eq (typeof this) 'string') (starts_with this '{')))}}
                 {{~#with (parse_json this)}}
                     {{#if (or (or this.title this.icon) this.image)}}
-                        <li class="nav-item{{#if this.submenu}} dropdown{{/if}}">
+                        <li class="nav-item{{#if this.submenu}} dropdown{{/if}}{{#if this.active}} active{{/if}}">
                             <a class="nav-link {{#if this.submenu}}dropdown-toggle{{/if}}" href="{{#if this.link}}{{this.link}}{{else}}#{{/if}}"
                                 {{~#if this.submenu}} data-bs-toggle="dropdown" data-bs-auto-close="outside" {{/if~}}
                                 {{#if this.target}}target="{{this.target}}"{{/if}}

--- a/testshell.sql
+++ b/testshell.sql
@@ -1,0 +1,6 @@
+select
+  'shell' as component
+  , true as sidebar
+  , '{"title": "Example Menu Item 1", "active": true}' as menu_item
+  , '{"title": "Example Menu Item 2"}' as menu_item
+


### PR DESCRIPTION
Allows the user to have SQL that indicates that a navigation bar should be shown as "active" in the shell.

```sql
select
  'shell' as component
  , '{"title": "Example Menu Item 1", "active": true}' as menu_item
  , '{"title": "Example Menu Item 2"}' as menu_item
```

![shell](https://github.com/user-attachments/assets/0789c0fb-7d4f-497d-b46b-1fc302faad8c)

Also works in the sidebar:

```sql
select
  'shell' as component
  , true as sidebar
  , '{"title": "Example Menu Item 1", "active": true}' as menu_item
  , '{"title": "Example Menu Item 2"}' as menu_item
```


![sidebar](https://github.com/user-attachments/assets/32c2f024-cbbf-4198-a572-5e262ebaec74)
