### PR TITLE
Add active indicator to the shell nav items

### DIFF
--- a/examples/official-site/sqlpage/migrations/01_documentation.sql
+++ b/examples/official-site/sqlpage/migrations/01_documentation.sql
@@ -1208,7 +1208,6 @@ and in its object form, to generate a dropdown menu named "Community" with links
 The object form can be used directly only on database engines that have a native JSON type.
 On other engines (such as SQLite), you can use the [`dynamic`](?component=dynamic#component) component to generate the same result.
 
-In this example, the "About" submenu is marked as active, which will highlight it in the navigation bar.
 
 You see the [page layouts demo](./examples/layouts.sql) for a live example of the different layouts.
 ',

--- a/examples/official-site/sqlpage/migrations/01_documentation.sql
+++ b/examples/official-site/sqlpage/migrations/01_documentation.sql
@@ -1218,7 +1218,7 @@ You see the [page layouts demo](./examples/layouts.sql) for a live example of th
             "icon": "database",
             "link": "/",
             "menu_item": [
-                {"active": true, "title": "About", "submenu": [
+                {"title": "About", "submenu": [
                     {"link": "/safety.sql", "title": "Security", "icon": "lock"},
                     {"link": "/performance.sql", "title": "Performance", "icon": "bolt"},
                     {"link": "//github.com/sqlpage/SQLPage/blob/main/LICENSE.txt", "title": "License", "icon": "file-text"},
@@ -1263,6 +1263,22 @@ You see the [page layouts demo](./examples/layouts.sql) for a live example of th
             "css": "/assets/highlightjs-and-tabler-theme.css",
             "footer": "[Built with SQLPage](https://github.com/sqlpage/SQLPage/tree/main/examples/official-site)"
         }]')),
+    ('shell', '
+This example shows how to set menu items as active in the navigation, so that they are highlighted in the nav bar.
+
+In this example you can see that two menu items are created, "Home" and "About" and the "Home" tab is marked as active.
+',
+     json('[{
+            "component": "shell",
+            "title": "SQLPage: SQL websites",
+            "icon": "database",
+            "link": "/",
+            "menu_item": [
+                {"title": "Home", "active": true},
+                {"title": "About"}
+            ]
+        }]')),
+
     ('shell', '
 ### Sharing the shell between multiple pages
 

--- a/examples/official-site/sqlpage/migrations/01_documentation.sql
+++ b/examples/official-site/sqlpage/migrations/01_documentation.sql
@@ -1208,6 +1208,8 @@ and in its object form, to generate a dropdown menu named "Community" with links
 The object form can be used directly only on database engines that have a native JSON type.
 On other engines (such as SQLite), you can use the [`dynamic`](?component=dynamic#component) component to generate the same result.
 
+In this example, the "About" submenu is marked as active, which will highlight it in the navigation bar.
+
 You see the [page layouts demo](./examples/layouts.sql) for a live example of the different layouts.
 ',
      json('[{
@@ -1216,7 +1218,7 @@ You see the [page layouts demo](./examples/layouts.sql) for a live example of th
             "icon": "database",
             "link": "/",
             "menu_item": [
-                {"title": "About", "submenu": [
+                {"active": true, "title": "About", "submenu": [
                     {"link": "/safety.sql", "title": "Security", "icon": "lock"},
                     {"link": "/performance.sql", "title": "Performance", "icon": "bolt"},
                     {"link": "//github.com/sqlpage/SQLPage/blob/main/LICENSE.txt", "title": "License", "icon": "file-text"},

--- a/sqlpage/templates/shell.handlebars
+++ b/sqlpage/templates/shell.handlebars
@@ -94,7 +94,7 @@
             {{~#if (or (eq (typeof this) 'object') (and (eq (typeof this) 'string') (starts_with this '{')))}}
                 {{~#with (parse_json this)}}
                     {{#if (or (or this.title this.icon) this.image)}}
-                        <li class="nav-item{{#if this.submenu}} dropdown{{/if}}">
+                        <li class="nav-item{{#if this.submenu}} dropdown{{/if}}{{#if this.active}} active{{/if}}">
                             <a class="nav-link {{#if this.submenu}}dropdown-toggle{{/if}}" href="{{#if this.link}}{{this.link}}{{else}}#{{/if}}"
                                 {{~#if this.submenu}} data-bs-toggle="dropdown" data-bs-auto-close="outside" {{/if~}}
                                 {{#if this.target}}target="{{this.target}}"{{/if}}


### PR DESCRIPTION
Allows the user to have SQL that indicates that a navigation bar should be shown as "active" in the shell.

```sql
select
  'shell' as component
  , '{"title": "Example Menu Item 1", "active": true}' as menu_item
  , '{"title": "Example Menu Item 2"}' as menu_item
```

![shell](https://github.com/user-attachments/assets/0789c0fb-7d4f-497d-b46b-1fc302faad8c)

Also works in the sidebar:

```sql
select
  'shell' as component
  , true as sidebar
  , '{"title": "Example Menu Item 1", "active": true}' as menu_item
  , '{"title": "Example Menu Item 2"}' as menu_item
```


![sidebar](https://github.com/user-attachments/assets/32c2f024-cbbf-4198-a572-5e262ebaec74)
