### PR TITLE
Added a compile time flag to compile SQLite with builtin math functions

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,4 +1,7 @@
 [env]
 # To use built-in math functions, this compile time flag must be set
 # See https://www.sqlite.org/draft/lang_mathfunc.html as a reference
-LIBSQLITE3_FLAGS = { value = "-DSQLITE_ENABLE_MATH_FUNCTIONS", force=true }
+# According to Cargo docs this will not overwrite any env var that was already
+# set by the user, and this is a good thing. If the user already set some
+# LIBSQLITE3_FLAGS, he probably knows what he is doing.
+LIBSQLITE3_FLAGS = "-DSQLITE_ENABLE_MATH_FUNCTIONS"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,4 @@
+[env]
+# To use built-in math functions, this compile time flag must be set
+# See https://www.sqlite.org/draft/lang_mathfunc.html as a reference
+LIBSQLITE3_FLAGS = { value = "-DSQLITE_ENABLE_MATH_FUNCTIONS", force=true }

--- a/tests/sql_test_files/it_works_sqrt.sql
+++ b/tests/sql_test_files/it_works_sqrt.sql
@@ -1,0 +1,7 @@
+set number_three = sqrt(9.0);
+
+select 'text' as component, 
+    case $number_three
+        when '3.0' then 'It works !'
+        else 'error: ' || coalesce($number_three, 'NULL')
+    end AS contents;


### PR DESCRIPTION
Closes #937

I think this is the easy way of setting the env var.
If we want to make this optional it could be implemented via features, but IMO making it optional would be overkill.