### PR TITLE
Dynamic routing with _.sql

### DIFF
--- a/src/webserver/http.rs
+++ b/src/webserver/http.rs
@@ -533,24 +533,25 @@ pub async fn run_server(config: &AppConfig, state: AppState) -> anyhow::Result<(
         }
         #[cfg(not(target_family = "unix"))]
         anyhow::bail!("Unix sockets are not supported on your operating system. Use listen_on instead of unix_socket.");
-    } else {
-        if let Some(domain) = &config.https_domain {
-            let mut listen_on_https = listen_on;
-            listen_on_https.set_port(443);
-            log::debug!("Will start HTTPS server on {listen_on_https}");
-            let config = make_auto_rustls_config(domain, config);
-            server = server
-                .bind_rustls_0_23(listen_on_https, config)
-                .map_err(|e| bind_error(e, listen_on_https))?;
-        } else if listen_on.port() == 443 {
-            bail!("Please specify a value for https_domain in the configuration file. This is required when using HTTPS (port 443)");
-        }
-        if listen_on.port() != 443 {
-            log::debug!("Will start HTTP server on {listen_on}");
-            server = server
-                .bind(listen_on)
-                .map_err(|e| bind_error(e, listen_on))?;
-        }
+    }
+
+    if let Some(domain) = &config.https_domain {
+        let mut listen_on_https = listen_on;
+        listen_on_https.set_port(443);
+        log::debug!("Will start HTTPS server on {listen_on_https}");
+        let config = make_auto_rustls_config(domain, config);
+        server = server
+            .bind_rustls_0_23(listen_on_https, config)
+            .map_err(|e| bind_error(e, listen_on_https))?;
+    } else if listen_on.port() == 443 {
+        bail!("Please specify a value for https_domain in the configuration file. This is required when using HTTPS (port 443)");
+    }
+
+    if listen_on.port() != 443 {
+        log::debug!("Will start HTTP server on {listen_on}");
+        server = server
+            .bind(listen_on)
+            .map_err(|e| bind_error(e, listen_on))?;
     }
 
     log_welcome_message(config);

--- a/src/webserver/routing.rs
+++ b/src/webserver/routing.rs
@@ -119,7 +119,10 @@ where
         path.push(INDEX);
         match find_file_or_not_found(&path, SQL_EXTENSION, store).await {
             Ok(NotFound) => {
-                let target_sql = path.parent().unwrap_or_else(|| Path::new("/")).join("_.sql");
+                let target_sql = path
+                    .parent()
+                    .unwrap_or_else(|| Path::new("/"))
+                    .join("_.sql");
                 if store.contains(&target_sql).await? {
                     Ok(Execute(target_sql))
                 } else {

--- a/src/webserver/routing.rs
+++ b/src/webserver/routing.rs
@@ -118,7 +118,10 @@ where
     if path_and_query.path().ends_with(FORWARD_SLASH) {
         path.push(INDEX);
         if let Ok(NotFound) = find_file_or_not_found(&path, SQL_EXTENSION, store).await {
-            let target_sql = path.parent().unwrap_or_else(|| Path::new("/")).join("_.sql");
+            let target_sql = path
+                .parent()
+                .unwrap_or_else(|| Path::new("/"))
+                .join("_.sql");
             if store.contains(&target_sql).await? {
                 Ok(Execute(target_sql))
             } else {

--- a/test/models/_.sql
+++ b/test/models/_.sql
@@ -1,2 +1,0 @@
-select sqlpage.path();
-select sqlpage.variables();

--- a/test/models/_.sql
+++ b/test/models/_.sql
@@ -1,0 +1,2 @@
+select sqlpage.path();
+select sqlpage.variables();


### PR DESCRIPTION
This update allow you to create a _.sql file that will catch all routing paths in its folder and all subpaths, while still respecting the 404.sql process already in place.

For example, if your folder structure is such:

/
/models
/models/_.sql
/models/example/404.sql

and if you have this code in the /models/_.sql:

```sql
select sqlpage.path();
select sqlpage.variables();
```

and you have this code in /models/example/404.sql:

```sql
select 'Sorry, this page was not found';
```

In your browser, you can access any of these URLs with this result:

1. / - this will render the default "It Works" page because there is no /index.sql
2. /test - This will render the default 404 page built into sqlpage because there is no /404.sql
3. /models/example/test - This will render "Sorry, this page was not found" because of /models/example/404.sql
4. /models/mymodel?id=3 - This will render a page with /models/mymodel as the path, and {id: 3} as variables. It was caught by /models/_.sql
5. /models/mymodel/submodel/test - This will render a page with /models/mymodel/submodel/test as the path, and {} as variables. It was caught by /models/_.sql
6. /models/mymodel/anything/anything_more/yet_even_more/still_going?id=5&val=2 - This will render a page with /models/mymodel/anything/anything_more/yet_even_more/still_going as the path, and {id: 5, val: 2} as variables because it was caught by /models/_.sql

This allows for some simple dynamic routing.