### PR TITLE
Fix concurrent oidc login cookie overwrites

### DIFF
--- a/src/webserver/oidc.rs
+++ b/src/webserver/oidc.rs
@@ -807,8 +807,7 @@ fn get_redirect_url_cookie(
     request: &ServiceRequest,
     csrf_token: &CsrfToken,
 ) -> anyhow::Result<Cookie<'static>> {
-    let state = csrf_token.secret();
-    let cookie_name = format!("{SQLPAGE_REDIRECT_URL_COOKIE_PREFIX}{state}");
+    let cookie_name = SQLPAGE_REDIRECT_URL_COOKIE_PREFIX.to_owned() + csrf_token.secret();
     request
         .cookie(&cookie_name)
         .with_context(|| format!("No {cookie_name} cookie found"))

--- a/src/webserver/oidc.rs
+++ b/src/webserver/oidc.rs
@@ -806,16 +806,12 @@ fn get_nonce_from_cookie(request: &ServiceRequest) -> anyhow::Result<Nonce> {
 fn get_redirect_url_cookie(
     request: &ServiceRequest,
     csrf_token: &CsrfToken,
-) -> Result<Cookie<'static>, anyhow::Error> {
-    let cookie_name = format!(
-        "{}{}",
-        SQLPAGE_REDIRECT_URL_COOKIE_PREFIX,
-        csrf_token.secret()
-    );
-    let cookie = request
+) -> anyhow::Result<Cookie<'static>> {
+    let state = csrf_token.secret();
+    let cookie_name = format!("{SQLPAGE_REDIRECT_URL_COOKIE_PREFIX}{state}");
+    request
         .cookie(&cookie_name)
-        .with_context(|| format!("No {cookie_name} cookie found"))?;
-    Ok(cookie)
+        .with_context(|| format!("No {cookie_name} cookie found"))
 }
 
 /// Given an audience, verify if it is trusted. The `client_id` is always trusted, independently of this function.

--- a/src/webserver/oidc.rs
+++ b/src/webserver/oidc.rs
@@ -442,7 +442,7 @@ async fn process_oidc_callback(
         })?
         .into_inner();
 
-    let redirect_url_cookie = get_redirect_url_cookie(request, &params.state)
+    let mut redirect_url_cookie = get_redirect_url_cookie(request, &params.state)
         .with_context(|| "Failed to read redirect URL from cookie")?;
 
     let client = oidc_state.get_client().await;
@@ -456,6 +456,7 @@ async fn process_oidc_callback(
     set_auth_cookie(&mut response, &token_response).context("Failed to set auth cookie")?;
 
     // Clean up the state-specific cookie after successful authentication
+    redirect_url_cookie.set_path("/");
     response.add_removal_cookie(&redirect_url_cookie)?;
 
     Ok(response)

--- a/src/webserver/oidc.rs
+++ b/src/webserver/oidc.rs
@@ -546,20 +546,10 @@ async fn get_authenticated_user_info(
         .with_context(|| format!("Invalid SQLPage auth cookie: {cookie_value:?}"))?;
 
     // Try to get nonce from cookies if this is a callback request
-    let nonce = if request.path() == SQLPAGE_REDIRECT_URI {
-        if let Ok(_params) = Query::<OidcCallbackParams>::from_query(request.query_string()) {
-            get_nonce_from_cookie(request).ok()
-        } else {
-            None
-        }
-    } else {
-        None
-    };
+    let nonce = get_nonce_from_cookie(request)?;
 
     log::debug!("Verifying id token: {id_token:?}");
-    let claims = oidc_state
-        .get_token_claims(id_token, nonce.as_ref())
-        .await?;
+    let claims = oidc_state.get_token_claims(id_token, Some(&nonce)).await?;
     log::debug!("The current user is: {claims:?}");
     Ok(Some(claims))
 }

--- a/src/webserver/oidc.rs
+++ b/src/webserver/oidc.rs
@@ -783,11 +783,7 @@ fn create_nonce_cookie(nonce: &Nonce) -> Cookie<'_> {
 }
 
 fn create_redirect_cookie<'a>(csrf_token: &CsrfToken, initial_url: &'a str) -> Cookie<'a> {
-    let cookie_name = format!(
-        "{}{}",
-        SQLPAGE_REDIRECT_URL_COOKIE_PREFIX,
-        csrf_token.secret()
-    );
+    let cookie_name = SQLPAGE_REDIRECT_URL_COOKIE_PREFIX.to_owned() + csrf_token.secret();
     Cookie::build(cookie_name, initial_url)
         .secure(true)
         .http_only(true)


### PR DESCRIPTION
Split OIDC state cookie into two separate cookies to prevent race conditions during concurrent login flows.

Previously, a single `sqlpage_oidc_state` cookie was used to store both the nonce and the redirect URL. When multiple OIDC login flows were initiated simultaneously in the same browser, this cookie would be overwritten, leading to authentication failures and loss of the intended redirect target. This change introduces a `sqlpage_oidc_nonce` cookie for the nonce and a short-lived, state-specific `sqlpage_oidc_state_{csrf_token}` cookie for the redirect URL, ensuring each login flow maintains its unique state.

---
<a href="https://cursor.com/background-agent?bcId=bc-695d4c43-b343-4780-a34c-6816e178ce04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-695d4c43-b343-4780-a34c-6816e178ce04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

