### PR TITLE
Allow large text fields in odbc

### DIFF
--- a/src/webserver/database/connect.rs
+++ b/src/webserver/database/connect.rs
@@ -208,6 +208,10 @@ fn set_custom_connect_options(options: &mut AnyConnectOptions, config: &AppConfi
     if let Some(sqlite_options) = options.as_sqlite_mut() {
         set_custom_connect_options_sqlite(sqlite_options, config);
     }
+	// Allow fetching very large text fields when using ODBC by removing the max column size limit
+	if let Some(odbc_options) = options.as_odbc_mut() {
+		*odbc_options = std::mem::take(odbc_options).max_column_size(None);
+	}
 }
 
 fn set_custom_connect_options_sqlite(
@@ -242,6 +246,10 @@ fn set_database_password(options: &mut AnyConnectOptions, password: &str) {
         *opts = take(opts).password(password);
     } else if let Some(opts) = options.as_mssql_mut() {
         *opts = take(opts).password(password);
+	} else if let Some(_opts) = options.as_odbc_mut() {
+		log::warn!(
+			"Setting a password for an ODBC connection is not supported via separate config; include credentials in the DSN or connection string"
+		);
     } else if let Some(_opts) = options.as_sqlite_mut() {
         log::warn!("Setting a password for a SQLite database is not supported");
     } else {


### PR DESCRIPTION
Set `OdbcConnectOptions::max_column_size(None)` to allow fetching large text fields and handle ODBC passwords by warning instead of panicking.

ODBC connections expect credentials to be part of the DSN or connection string. Previously, attempting to set a password separately for an ODBC connection could lead to unexpected behavior or panics; this change now logs a warning and ignores the separate password.

---
<a href="https://cursor.com/background-agent?bcId=bc-4f52ab4a-3f89-49a3-9cce-24ea3e3099d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4f52ab4a-3f89-49a3-9cce-24ea3e3099d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

