### PR TITLE
Add image height property to card component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,19 @@
 # CHANGELOG.md
 
-## v0.39.1 (2025-11-08)
- - More precise server timing tracking to debug performance issues
- - Fix missing server timing header in some cases
- - Implement nice error messages for some header-related errors such as invalid header values.
- - `compress_responses` is now set to `false` by default in the configuration.
-  - When response compression is enabled, additional buffering is needed. Users reported a better experience with pages that load more progressively, reducing the time before the pages' shell is rendered.
-  - When SQLPage is deployed behind a reverse proxy, compressing responses between sqlpage and the proxy is wasteful.
- - In the table component, allow simple objects in custom_actions instead of requiring arrays of objects.
- - Fatser icon loading. Previously, even a page containing a single icon required downloading and parsing a ~2MB file. This resulted in a delay where pages initially appeared with a blank space before icons appeared. Icons are now inlined inside pages and appear instantaneously.
- - Updated tabler icons to 3.35
- - Fix inaccurate ODBC warnings
- - Added support for Microsoft SQL Server named instances: `mssql://user:pass@localhost/db?instance_name=xxx`
- - Added a detailed [performance guide](https://sql-page.com/blog?post=Performance+Guide) to the docs.
+ ## v0.39.1 (2025-11-08)
+  - More precise server timing tracking to debug performance issues
+  - Fix missing server timing header in some cases
+  - Implement nice error messages for some header-related errors such as invalid header values.
+  - `compress_responses` is now set to `false` by default in the configuration.
+   - When response compression is enabled, additional buffering is needed. Users reported a better experience with pages that load more progressively, reducing the time before the pages' shell is rendered.
+   - When SQLPage is deployed behind a reverse proxy, compressing responses between sqlpage and the proxy is wasteful.
+  - In the table component, allow simple objects in custom_actions instead of requiring arrays of objects.
+  - Fatser icon loading. Previously, even a page containing a single icon required downloading and parsing a ~2MB file. This resulted in a delay where pages initially appeared with a blank space before icons appeared. Icons are now inlined inside pages and appear instantaneously.
+  - Updated tabler icons to 3.35
+  - Fix inaccurate ODBC warnings
+  - Added support for Microsoft SQL Server named instances: `mssql://user:pass@localhost/db?instance_name=xxx`
+  - Added a detailed [performance guide](https://sql-page.com/blog?post=Performance+Guide) to the docs.
+  - Added an `image_height` property to the card component so top images can be capped without stretching or upscaling.
 
 ## v0.39.0 (2025-10-28)
  - Ability to execute sql for URL paths with another extension. If you create sitemap.xml.sql, it will be executed for example.com/sitemap.xml

--- a/examples/official-site/sqlpage/migrations/31_card_docs_update.sql
+++ b/examples/official-site/sqlpage/migrations/31_card_docs_update.sql
@@ -18,6 +18,7 @@ INSERT INTO parameter(component, name, description, type, top_level, optional) S
         This is useful if you want to display a lot of text in the card, with many options for formatting, such as
         line breaks, **bold**, *italics*, lists, #titles, [links](target.sql), ![images](photo.jpg), etc.', 'TEXT', FALSE, TRUE),
     ('top_image', 'The URL (absolute or relative) of an image to display at the top of the card.', 'URL', FALSE, TRUE),
+    ('image_height', 'Maximum height for the top image. The image will scale down to fit this height without distorting or upscaling.', 'TEXT', FALSE, TRUE),
     ('footer', 'Muted text to display at the bottom of the card.', 'TEXT', FALSE, TRUE),
     ('footer_md', 'Muted text to display at the bottom of the card, with rich text formatting in Markdown format.', 'TEXT', FALSE, TRUE),
     ('link', 'An URL to which the user should be taken when they click on the card.', 'URL', FALSE, TRUE),
@@ -58,9 +59,9 @@ INSERT INTO example(component, description, properties) VALUES
     ('card', 'A gallery of images.',
         json('[
             {"component":"card", "title":"My favorite animals in pictures", "columns": 3},
-            {"title": "Lynx", "description_md": "The **lynx** is a medium-sized **wild cat** native to Northern, Central and Eastern Europe to Central Asia and Siberia, the Tibetan Plateau and the Himalayas.", "top_image": "https://upload.wikimedia.org/wikipedia/commons/thumb/d/d8/Lynx_lynx-4.JPG/640px-Lynx_lynx-4.JPG", "icon":"star" },
-            {"title": "Squirrel", "description_md": "The **chipmunk** is a small, striped rodent of the family Sciuridae. Chipmunks are found in North America, with the exception of the Siberian chipmunk which is found primarily in Asia.", "top_image": "https://upload.wikimedia.org/wikipedia/commons/thumb/b/be/Tamias-rufus-001.jpg/640px-Tamias-rufus-001.jpg" },
-            {"title": "Spider", "description_md": "The **jumping spider family** (_Salticidae_) contains more than 600 described genera and about *6000 described species*, making it the largest family of spiders with about 13% of all species.", "top_image": "https://upload.wikimedia.org/wikipedia/commons/thumb/a/ab/Jumping_spiders_%28Salticidae%29.jpg/640px-Jumping_spiders_%28Salticidae%29.jpg" }
+            {"title": "Lynx", "description_md": "The **lynx** is a medium-sized **wild cat** native to Northern, Central and Eastern Europe to Central Asia and Siberia, the Tibetan Plateau and the Himalayas.", "top_image": "https://upload.wikimedia.org/wikipedia/commons/thumb/d/d8/Lynx_lynx-4.JPG/640px-Lynx_lynx-4.JPG", "image_height": "12rem", "icon":"star" },
+            {"title": "Squirrel", "description_md": "The **chipmunk** is a small, striped rodent of the family Sciuridae. Chipmunks are found in North America, with the exception of the Siberian chipmunk which is found primarily in Asia.", "top_image": "https://upload.wikimedia.org/wikipedia/commons/thumb/b/be/Tamias-rufus-001.jpg/640px-Tamias-rufus-001.jpg", "image_height": "12rem" },
+            {"title": "Spider", "description_md": "The **jumping spider family** (_Salticidae_) contains more than 600 described genera and about *6000 described species*, making it the largest family of spiders with about 13% of all species.", "top_image": "https://upload.wikimedia.org/wikipedia/commons/thumb/a/ab/Jumping_spiders_%28Salticidae%29.jpg/640px-Jumping_spiders_%28Salticidae%29.jpg", "image_height": "12rem" }
         ]')),
     ('card', 'Beautifully colored cards with variable width. The blue card (width 6) takes half the screen, whereas of the red and green cards have the default width of 3',
         json('[

--- a/examples/official-site/sqlpage/migrations/31_card_docs_update.sql
+++ b/examples/official-site/sqlpage/migrations/31_card_docs_update.sql
@@ -18,7 +18,7 @@ INSERT INTO parameter(component, name, description, type, top_level, optional) S
         This is useful if you want to display a lot of text in the card, with many options for formatting, such as
         line breaks, **bold**, *italics*, lists, #titles, [links](target.sql), ![images](photo.jpg), etc.', 'TEXT', FALSE, TRUE),
     ('top_image', 'The URL (absolute or relative) of an image to display at the top of the card.', 'URL', FALSE, TRUE),
-    ('image_height', 'Maximum height for the top image. The image will scale down to fit this height without distorting or upscaling.', 'TEXT', FALSE, TRUE),
+    ('image_height', 'Maximum height in pixels for the top image. The image will scale down to fit this height without distorting or upscaling.', 'INTEGER', FALSE, TRUE),
     ('footer', 'Muted text to display at the bottom of the card.', 'TEXT', FALSE, TRUE),
     ('footer_md', 'Muted text to display at the bottom of the card, with rich text formatting in Markdown format.', 'TEXT', FALSE, TRUE),
     ('link', 'An URL to which the user should be taken when they click on the card.', 'URL', FALSE, TRUE),
@@ -59,9 +59,9 @@ INSERT INTO example(component, description, properties) VALUES
     ('card', 'A gallery of images.',
         json('[
             {"component":"card", "title":"My favorite animals in pictures", "columns": 3},
-            {"title": "Lynx", "description_md": "The **lynx** is a medium-sized **wild cat** native to Northern, Central and Eastern Europe to Central Asia and Siberia, the Tibetan Plateau and the Himalayas.", "top_image": "https://upload.wikimedia.org/wikipedia/commons/thumb/d/d8/Lynx_lynx-4.JPG/640px-Lynx_lynx-4.JPG", "image_height": "12rem", "icon":"star" },
-            {"title": "Squirrel", "description_md": "The **chipmunk** is a small, striped rodent of the family Sciuridae. Chipmunks are found in North America, with the exception of the Siberian chipmunk which is found primarily in Asia.", "top_image": "https://upload.wikimedia.org/wikipedia/commons/thumb/b/be/Tamias-rufus-001.jpg/640px-Tamias-rufus-001.jpg", "image_height": "12rem" },
-            {"title": "Spider", "description_md": "The **jumping spider family** (_Salticidae_) contains more than 600 described genera and about *6000 described species*, making it the largest family of spiders with about 13% of all species.", "top_image": "https://upload.wikimedia.org/wikipedia/commons/thumb/a/ab/Jumping_spiders_%28Salticidae%29.jpg/640px-Jumping_spiders_%28Salticidae%29.jpg", "image_height": "12rem" }
+            {"title": "Lynx", "description_md": "The **lynx** is a medium-sized **wild cat** native to Northern, Central and Eastern Europe to Central Asia and Siberia, the Tibetan Plateau and the Himalayas.", "top_image": "https://upload.wikimedia.org/wikipedia/commons/thumb/d/d8/Lynx_lynx-4.JPG/640px-Lynx_lynx-4.JPG", "image_height": 220, "icon":"star" },
+            {"title": "Squirrel", "description_md": "The **chipmunk** is a small, striped rodent of the family Sciuridae. Chipmunks are found in North America, with the exception of the Siberian chipmunk which is found primarily in Asia.", "top_image": "https://upload.wikimedia.org/wikipedia/commons/thumb/b/be/Tamias-rufus-001.jpg/640px-Tamias-rufus-001.jpg", "image_height": 220 },
+            {"title": "Spider", "description_md": "The **jumping spider family** (_Salticidae_) contains more than 600 described genera and about *6000 described species*, making it the largest family of spiders with about 13% of all species.", "top_image": "https://upload.wikimedia.org/wikipedia/commons/thumb/a/ab/Jumping_spiders_%28Salticidae%29.jpg/640px-Jumping_spiders_%28Salticidae%29.jpg", "image_height": 220 }
         ]')),
     ('card', 'Beautifully colored cards with variable width. The blue card (width 6) takes half the screen, whereas of the red and green cards have the default width of 3',
         json('[

--- a/sqlpage/sqlpage.css
+++ b/sqlpage/sqlpage.css
@@ -22,6 +22,17 @@ td > p {
   margin-bottom: 0 !important;
 }
 
+.card-img-top-constrained {
+  width: auto;
+  max-width: 100%;
+  height: auto;
+  max-height: var(--sqlpage-card-image-height, none);
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+  object-fit: scale-down;
+}
+
 .text-secondary a {
   color: inherit;
   text-decoration: underline;

--- a/sqlpage/templates/card.handlebars
+++ b/sqlpage/templates/card.handlebars
@@ -39,8 +39,8 @@
                 {{/if}}
                 {{#if top_image}}
                     <img src="{{top_image}}"
-                        class="card-img-top{{#if image_height}} card-img-top-constrained mx-auto{{/if}}"
-                        {{#if image_height}}style="--sqlpage-card-image-height: {{image_height}};"{{/if}} />
+                        class="card-img-top{{#if image_height}} mw-100 w-auto h-auto mx-auto{{/if}}"
+                        {{#if image_height}}style="max-height: {{image_height}}px;"{{/if}} />
                 {{/if}}
                 {{#if color}}
                     {{#if (not embed)}}

--- a/sqlpage/templates/card.handlebars
+++ b/sqlpage/templates/card.handlebars
@@ -38,7 +38,9 @@
                     <a href="{{link}}" style="text-decoration: inherit; color: inherit">
                 {{/if}}
                 {{#if top_image}}
-                    <img src="{{top_image}}" class="card-img-top" />
+                    <img src="{{top_image}}"
+                        class="card-img-top{{#if image_height}} card-img-top-constrained mx-auto{{/if}}"
+                        {{#if image_height}}style="--sqlpage-card-image-height: {{image_height}};"{{/if}} />
                 {{/if}}
                 {{#if color}}
                     {{#if (not embed)}}


### PR DESCRIPTION
Add `image_height` property to the card component to set the maximum height of images.

This property ensures images scale down proportionally to fit the specified height, without distortion or upscaling, by using `object-fit: scale-down` and a CSS variable.

---
<a href="https://cursor.com/background-agent?bcId=bc-267a9c83-5a59-4b6f-95b9-770632345fd2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-267a9c83-5a59-4b6f-95b9-770632345fd2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

