### PR TITLE
WIP: Optimize run_sql by avoiding cloning immutable data

### DIFF
--- a/examples/official-site/sqlpage/migrations/20_variables_function.sql
+++ b/examples/official-site/sqlpage/migrations/20_variables_function.sql
@@ -9,9 +9,26 @@ VALUES (
     'variables',
     '0.15.0',
     'variable',
-    'Returns a JSON string containing all variables passed as URL parameters or posted through a form.
+    'Returns a JSON string containing variables from the HTTP request and user-defined variables.
 
 The database''s json handling functions can then be used to process the data.
+
+## Variable Types
+
+SQLPage distinguishes between three types of variables:
+
+- **GET variables**: URL parameters from the query string (immutable)
+- **POST variables**: Form data from POST requests (immutable)  
+- **SET variables**: User-defined variables created with the `SET` command (mutable)
+
+## Usage
+
+- `sqlpage.variables()` - returns all variables (GET, POST, and SET combined, with SET variables taking precedence)
+- `sqlpage.variables(''get'')` - returns only URL parameters
+- `sqlpage.variables(''post'')` - returns only POST form data
+- `sqlpage.variables(''set'')` - returns only user-defined variables created with `SET`
+
+When a SET variable has the same name as a GET or POST variable, the SET variable takes precedence in the combined result.
 
 ## Example: a form with a variable number of fields
 
@@ -95,6 +112,6 @@ VALUES (
     'variables',
     1,
     'method',
-    'Optional. The HTTP request method (GET or POST). Must be a literal string. When not provided, all variables are returned.',
+    'Optional. Filter variables by source: ''get'' (URL parameters), ''post'' (form data), or ''set'' (user-defined variables). When not provided, all variables are returned with SET variables taking precedence over request parameters.',
     'TEXT'
 );

--- a/src/webserver/database/execute_queries.rs
+++ b/src/webserver/database/execute_queries.rs
@@ -258,9 +258,13 @@ fn vars_and_name<'a, 'b>(
     variable: &'b StmtParam,
 ) -> anyhow::Result<(std::cell::RefMut<'a, HashMap<String, SingleOrVec>>, &'b str)> {
     match variable {
-        StmtParam::PostOrGet(name) | StmtParam::Get(name) | StmtParam::Post(name) => {
+        StmtParam::PostOrGet(name) | StmtParam::Get(name) => {
+            if request.post_variables.contains_key(name) {
+                log::warn!("Deprecation warning! Setting the value of ${name}, but there is already a form field named :{name}. This will stop working soon. Please rename the variable, or use :{name} directly if you intended to overwrite the posted form field value.");
+            }
             Ok((request.set_variables.borrow_mut(), name))
         }
+        StmtParam::Post(name) => Ok((request.set_variables.borrow_mut(), name)),
         _ => Err(anyhow!(
             "Only GET and POST variables can be set, not {variable:?}"
         )),

--- a/src/webserver/database/sqlpage_functions/functions.rs
+++ b/src/webserver/database/sqlpage_functions/functions.rs
@@ -569,8 +569,8 @@ async fn run_sql<'a>(
         )
         .await
         .with_context(|| format!("run_sql: invalid path {sql_file_path:?}"))?;
-    let tmp_req = if let Some(variables) = variables {
-        let tmp_req = request.clone_without_variables();
+    let tmp_req = request.clone_without_variables();
+    if let Some(variables) = variables {
         let variables: ParamMap = serde_json::from_str(&variables).map_err(|err| {
             let context = format!(
                 "run_sql: unable to parse the variables argument (line {}, column {})",
@@ -580,10 +580,8 @@ async fn run_sql<'a>(
             anyhow::Error::new(err).context(context)
         })?;
         tmp_req.set_variables.replace(variables);
-        tmp_req
-    } else {
-        request.clone()
-    };
+    }
+    // else: inherit set_variables from parent (already empty from clone_without_variables)
     let max_recursion_depth = app_state.config.max_recursion_depth;
     if tmp_req.clone_depth > max_recursion_depth {
         anyhow::bail!("Too many nested inclusions. run_sql can include a file that includes another file, but the depth is limited to {max_recursion_depth} levels. \n\

--- a/src/webserver/http.rs
+++ b/src/webserver/http.rs
@@ -174,7 +174,7 @@ async fn render_sql(
         .clone()
         .into_inner();
 
-    let mut req_param = extract_request_info(srv_req, Arc::clone(&app_state), server_timing)
+    let req_param = extract_request_info(srv_req, Arc::clone(&app_state), server_timing)
         .await
         .map_err(|e| anyhow_err_to_actix(e, &app_state))?;
     log::debug!("Received a request with the following parameters: {req_param:?}");
@@ -185,14 +185,14 @@ async fn render_sql(
     let source_path: PathBuf = sql_file.source_path.clone();
     actix_web::rt::spawn(async move {
         let request_context = RequestContext {
-            is_embedded: req_param.get_variables.contains_key("_sqlpage_embed"),
+            is_embedded: req_param.url_params.contains_key("_sqlpage_embed"),
             source_path,
             content_security_policy: ContentSecurityPolicy::with_random_nonce(),
             server_timing: Arc::clone(&req_param.server_timing),
         };
         let mut conn = None;
         let database_entries_stream =
-            stream_query_results_with_conn(&sql_file, &mut req_param, &mut conn);
+            stream_query_results_with_conn(&sql_file, &req_param, &mut conn);
         let database_entries_stream = stop_at_first_error(database_entries_stream);
         let response_with_writer = build_response_header_and_stream(
             Arc::clone(&app_state),

--- a/src/webserver/http_request_info.rs
+++ b/src/webserver/http_request_info.rs
@@ -35,17 +35,22 @@ pub struct RequestInfo {
     pub protocol: String,
     pub url_params: ParamMap,
     pub post_variables: ParamMap,
-    pub set_variables: RefCell<ParamMap>,
     pub uploaded_files: Rc<HashMap<String, TempFile>>,
     pub headers: ParamMap,
     pub client_ip: Option<IpAddr>,
     pub cookies: ParamMap,
     pub basic_auth: Option<Basic>,
     pub app_state: Arc<AppState>,
-    pub clone_depth: u8,
     pub raw_body: Option<Vec<u8>>,
     pub oidc_claims: Option<OidcClaims>,
     pub server_timing: Arc<super::server_timing::ServerTiming>,
+}
+
+#[derive(Debug)]
+pub struct ExecutionContext {
+    pub request: Rc<RequestInfo>,
+    pub set_variables: RefCell<ParamMap>,
+    pub clone_depth: u8,
 }
 
 impl RequestInfo {

--- a/tests/sql_test_files/it_works_immutable_variables.sql
+++ b/tests/sql_test_files/it_works_immutable_variables.sql
@@ -1,0 +1,33 @@
+SET x = 'set_value';
+SET set_only = 'only_in_set';
+
+SELECT 'text' AS component;
+
+SELECT CASE 
+    WHEN $x = 'set_value' THEN 'It works !'
+    WHEN $x = '1' THEN 'FAIL: SET variable should shadow URL param'
+    ELSE 'FAIL: Unexpected value for $x: ' || COALESCE($x, 'NULL')
+END AS contents;
+
+SELECT CASE
+    WHEN $set_only = 'only_in_set' THEN 'It works !'
+    ELSE 'FAIL: SET-only variable not found'
+END AS contents;
+
+SELECT CASE
+    WHEN json_extract(sqlpage.variables('get'), '$.x') = '1' THEN 'It works !'
+    ELSE 'FAIL: variables(''get'') should return only URL parameters'
+END AS contents;
+
+SELECT CASE
+    WHEN json_extract(sqlpage.variables('set'), '$.x') = 'set_value' AND
+         json_extract(sqlpage.variables('set'), '$.set_only') = 'only_in_set' THEN 'It works !'
+    ELSE 'FAIL: variables(''set'') should return only SET variables'
+END AS contents;
+
+SELECT CASE
+    WHEN json_extract(sqlpage.variables(), '$.x') = 'set_value' AND
+         json_extract(sqlpage.variables(), '$.set_only') = 'only_in_set' THEN 'It works !'
+    ELSE 'FAIL: variables() should merge all with SET taking precedence'
+END AS contents;
+


### PR DESCRIPTION
**STATUS: DRAFT / WORK IN PROGRESS - Does not compile yet**

This PR refactors the request handling to separate immutable request data from mutable execution state, avoiding unnecessary cloning of potentially large data structures.

## Problem
Currently, `run_sql()` clones the entire `RequestInfo` which includes:
- All HTTP headers
- All cookies  
- Request body
- URL parameters
- POST parameters
- Uploaded file references

This is wasteful since only `set_variables` and `clone_depth` need to be cloned.

## Solution
Split into two structures:
- `RequestInfo`: immutable request data (wrapped in `Rc`)
- `ExecutionContext`: mutable execution state + reference to RequestInfo

## Benefits
- Avoid cloning large strings in nested `run_sql()` calls
- Clearer separation of concerns
- Better performance for recursive SQL includes

## Status
- [x] Define new structures
- [ ] Update all function signatures (~50+ functions)
- [ ] Update execute_queries.rs
- [ ] Update syntax_tree.rs  
- [ ] Update sqlpage_functions
- [ ] Tests passing

Based on: #1109