### PR TITLE
Update hash password documentation for clarity

### DIFF
--- a/examples/official-site/sqlpage/migrations/08_functions.sql
+++ b/examples/official-site/sqlpage/migrations/08_functions.sql
@@ -157,8 +157,11 @@ VALUES (
         '0.7.2',
         'spy',
         '
-Hashes a password using the [Argon2](https://en.wikipedia.org/wiki/Argon2) algorithm.
-The resulting hash can be stored in the database and then used with the [authentication component](documentation.sql?component=authentication#component).
+Hashes a password with the Argon2id variant and outputs it in the [PHC string format](https://github.com/P-H-C/phc-string-format/blob/master/phc-sf-spec.md), ready to store in your users table.
+
+Every call generates a brand new cryptographic salt so that two people choosing the same password still end up with different hashes, which defeats rainbow-table attacks and lets you safely reveal only the hash.
+
+Use this function only when creating or resetting a password (for example while inserting a brand new user): it writes the stored value. Later, at login time, the [authentication component](documentation.sql?component=authentication#component) reads the stored hash, hashes the visitor''s password with the embedded salt and parameters, and grants access only if they match.
 
 ### Example
 


### PR DESCRIPTION
Update `hash_password` documentation to be more pedagogical, explaining salt generation, usage, and verification for beginners.

---
<a href="https://cursor.com/background-agent?bcId=bc-e82163d6-20e4-4a44-aaed-6258646d7b69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e82163d6-20e4-4a44-aaed-6258646d7b69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

