### PR TITLE
Update logout url logic

### DIFF
--- a/examples/official-site/sqlpage/migrations/61_oidc_functions.sql
+++ b/examples/official-site/sqlpage/migrations/61_oidc_functions.sql
@@ -192,6 +192,8 @@ When a user visits this URL, SQLPage will:
 2. Redirect the user to the OIDC provider''s logout endpoint (if available)
 3. Finally redirect back to the specified `redirect_uri`
 
+The generated link now appends the current user''s OIDC `sub` identifier as the `user_id` query parameter, so you can display or log which account will be signed out. If no user is currently authenticated, the function simply returns the provided `redirect_uri`, avoiding unnecessary redirects.
+
 ## Security Features
 
 This function provides protection against **Cross-Site Request Forgery (CSRF)** attacks:

--- a/src/webserver/database/sqlpage_functions/functions.rs
+++ b/src/webserver/database/sqlpage_functions/functions.rs
@@ -876,10 +876,15 @@ async fn oidc_logout_url<'a>(
         );
     }
 
+    let Some(claims) = request.oidc_claims.as_ref() else {
+        return Ok(Some(redirect_uri.to_string()));
+    };
+
     let logout_url = crate::webserver::oidc::create_logout_url(
         redirect_uri,
         &request.app_state.config.site_prefix,
         &oidc_state.config.client_secret,
+        Some(claims.subject().as_str()),
     );
 
     Ok(Some(logout_url))


### PR DESCRIPTION
Include the OIDC user ID in logout URLs for authenticated users and fall back to the redirect URL for anonymous users to provide a meaningful destination.

---
<a href="https://cursor.com/background-agent?bcId=bc-6c83edd0-9987-46b7-be96-dd191fa74cc1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6c83edd0-9987-46b7-be96-dd191fa74cc1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

