### PR TITLE
Oidc logout redirect url

### DIFF
--- a/src/webserver/oidc.rs
+++ b/src/webserver/oidc.rs
@@ -503,7 +503,7 @@ async fn process_oidc_logout(
     let mut response =
         if let Some(end_session_endpoint) = oidc_state.get_end_session_endpoint().await {
             let absolute_redirect_uri =
-                build_absolute_uri(&oidc_state.config.app_host, &params.redirect_uri, scheme)?;
+                build_absolute_uri(&oidc_state.config.app_host, &params.redirect_uri, &scheme)?;
             let post_logout_redirect_uri =
                 PostLogoutRedirectUrl::new(absolute_redirect_uri.clone()).with_context(|| {
                     format!("Invalid post_logout_redirect_uri: {absolute_redirect_uri}")


### PR DESCRIPTION
Refactor OIDC URL scheme inference to correctly generate HTTPS logout redirect URLs when behind a reverse proxy.

The `process_oidc_logout` function was determining the URL scheme from the internal connection, which is HTTP when SQLPage is behind an SSL-terminating reverse proxy like Nginx. This resulted in `http://` logout redirect URLs, which are rejected by OIDC providers like Keycloak. This change extracts and reuses the existing `app_host` configuration logic to infer the correct external scheme (HTTPS) for logout redirects.

---
<a href="https://cursor.com/background-agent?bcId=bc-c66b3888-d8ca-4b1a-9f37-713988c5fdd3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c66b3888-d8ca-4b1a-9f37-713988c5fdd3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

