### PR TITLE
Add item-level id support to datagrid component

### DIFF
--- a/examples/official-site/sqlpage/migrations/99_shared_id_class_attributes.sql
+++ b/examples/official-site/sqlpage/migrations/99_shared_id_class_attributes.sql
@@ -7,6 +7,7 @@ FROM (VALUES
     ('code', TRUE),
     ('csv', TRUE),
     ('datagrid', TRUE),
+    ('datagrid', FALSE),
     ('hero', TRUE),
     ('list', TRUE),
     ('list', FALSE),

--- a/sqlpage/templates/datagrid.handlebars
+++ b/sqlpage/templates/datagrid.handlebars
@@ -21,7 +21,7 @@
     <div class="card-body">
         <div class="datagrid">
             {{#each_row}}
-                <div class="datagrid-item">
+                <div class="datagrid-item" {{#if id}}id="{{id}}"{{/if}}>
                     <div class="datagrid-title">{{title}}</div>
                     <div class="datagrid-content {{#if active}}fw-bold{{/if}}">
                         {{~#if link}}


### PR DESCRIPTION
### Motivation
- Allow each datagrid item to expose an HTML `id` so pages can target or style individual rows (useful for in-page anchors and CSS selectors) and ensure the feature is documented in the official-site migrations.

### Description
- Render an optional `id` attribute on each datagrid item by updating `sqlpage/templates/datagrid.handlebars` to output `id="{{id}}"` when present, and add `('datagrid', FALSE)` to `examples/official-site/sqlpage/migrations/99_shared_id_class_attributes.sql` to document the item-level `id` parameter.

### Testing
- Ran `cargo test`, which could not complete because the build script attempted to download external frontend assets and failed with `Network is unreachable (os error 101)`, preventing the full test/run in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6731cd6a08331b3eddd95ebd6c72d)