### PR TITLE
new function: sqlpage.regex_match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+- New function: `sqlpage.regex_match(pattern, text)`. Useful for easy routing using `sqlpage.path()` from 404.sql files.
 - Added a `show_legend` top level property to the chart component.
 - Updated apex charts from 5.3 to 5.10. See https://github.com/apexcharts/apexcharts.js/releases
 - fixed unreadable chart toolbar menu when using the dark theme

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4446,6 +4446,7 @@ dependencies = [
  "password-hash",
  "percent-encoding",
  "rand 0.10.0",
+ "regex",
  "rustls",
  "rustls-acme",
  "rustls-native-certs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ tokio-util = "0.7.12"
 openidconnect = { version = "4.0.0", default-features = false, features = ["accept-rfc3339-timestamps"] }
 encoding_rs = "0.8.35"
 odbc-sys = { version = "0.29.0", optional = true }
+regex = "1"
 
 # OpenTelemetry / tracing
 tracing = "0.1"

--- a/examples/official-site/sqlpage/migrations/74_regex_match.sql
+++ b/examples/official-site/sqlpage/migrations/74_regex_match.sql
@@ -61,9 +61,11 @@ where category = $route->>''category''
 ### Details
 
 - Quick regex reminder:
-- `\w+` matches one or more "word" characters
-- `\d+` matches one or more digits
-- `(?<name>...)` creates a named capture group
+  - `\w+` matches one or more "word" characters
+  - `\d+` matches one or more digits
+  - `(?<name>...)` creates a named capture group
+- Some databases, such as MySQL and MariaDB, treat backslashes specially inside SQL strings.
+  In those databases, you may need to write `\\w` and `\\d`, or use portable character classes such as `[A-Za-z0-9_]` and `[0-9]` instead.
 - In SQLite, PostgreSQL, and some other databases, you can read fields from the returned JSON with `->` and `->>`
 - On databases that do not support that syntax, use their JSON extraction function instead, such as `json_extract($route, ''$.category'')`
 - For the full regular expression syntax supported by SQLPage, see the Rust `regex` crate documentation:

--- a/examples/official-site/sqlpage/migrations/74_regex_match.sql
+++ b/examples/official-site/sqlpage/migrations/74_regex_match.sql
@@ -1,0 +1,101 @@
+INSERT INTO
+    sqlpage_functions (
+        "name",
+        "introduced_in_version",
+        "icon",
+        "description_md"
+    )
+VALUES
+    (
+        'regex_match',
+        '0.43.0',
+        'regex',
+        'Matches a text value against a regular expression and returns the capture groups as a JSON object.
+
+If the text matches the pattern, the result contains one entry for each capture group that matched:
+- key `0` contains the full match
+- named groups like `(?<name>...)` use their name as the JSON key
+- unnamed groups like `( ... )` use their numeric index as a string
+
+If the text does not match, this function returns `NULL`.
+
+### Example: custom routing from `404.sql`
+
+This function is especially useful in a custom [`404.sql` page](/your-first-sql-website/custom_urls.sql),
+where you want to turn a dynamic URL into variables your SQL can use.
+
+For example, suppose you want `/categories/{category}/post/{id}` URLs such as `/categories/sql/post/42`,
+but there is no physical `categories/sql/post/42.sql` file on disk.
+You can put a `categories/404.sql` file in your project and extract the dynamic parts from the URL:
+
+#### `categories/404.sql`
+```sql
+set route = sqlpage.regex_match(
+  ''/categories/(?<category>\w+)/post/(?<id>\d+)'',
+  sqlpage.path()
+);
+
+select ''redirect'' as component, ''/404'' as link
+where $route is null;
+
+select ''text'' as component;
+select
+  ''Category: '' || ($route->>''category'') || '' | Post id: '' || ($route->>''id'') as contents;
+```
+
+If the current path is `/categories/sql/post/42`, `sqlpage.regex_match()` returns:
+
+```json
+{"0":"/categories/sql/post/42","category":"sql","id":"42"}
+```
+
+You can then use those extracted values to query your database:
+
+```sql
+select title, body
+from posts
+where category = $route->>''category''
+  and id = cast($route->>''id'' as integer);
+```
+
+### Details
+
+- Quick regex reminder:
+- `\w+` matches one or more "word" characters
+- `\d+` matches one or more digits
+- `(?<name>...)` creates a named capture group
+- In SQLite, PostgreSQL, and some other databases, you can read fields from the returned JSON with `->` and `->>`
+- On databases that do not support that syntax, use their JSON extraction function instead, such as `json_extract($route, ''$.category'')`
+- For the full regular expression syntax supported by SQLPage, see the Rust `regex` crate documentation:
+  [regex syntax reference](https://docs.rs/regex/latest/regex/#syntax)
+- If the input text is `NULL`, the function returns `NULL`
+- If an optional capture group does not match, that key is omitted from the JSON object
+- If the regular expression is invalid, SQLPage returns an error
+
+The returned JSON can then be processed with your database''s JSON functions.
+'
+    );
+
+INSERT INTO
+    sqlpage_function_parameters (
+        "function",
+        "index",
+        "name",
+        "description_md",
+        "type"
+    )
+VALUES
+    (
+        'regex_match',
+        1,
+        'pattern',
+        'The regular expression pattern to match against the input text. Named capture groups such as `(?<name>...)` are supported.',
+        'TEXT'
+    ),
+    (
+        'regex_match',
+        2,
+        'text',
+        'The text to match against the regular expression. Returns `NULL` when this argument is `NULL`.',
+        'TEXT'
+    );

--- a/src/webserver/database/sqlpage_functions/functions.rs
+++ b/src/webserver/database/sqlpage_functions/functions.rs
@@ -50,6 +50,7 @@ super::function_definition_macro::sqlpage_functions! {
     random_string(string_length: SqlPageFunctionParam<usize>);
     read_file_as_data_url((&RequestInfo), file_path: Option<Cow<str>>);
     read_file_as_text((&RequestInfo), file_path: Option<Cow<str>>);
+    regex_match(pattern: Cow<str>, text: Option<Cow<str>>);
     request_method((&RequestInfo));
     run_sql((&ExecutionContext, &mut DbConn), sql_file_path: Option<Cow<str>>, variables: Option<Cow<str>>);
     set_variable((&ExecutionContext), name: Cow<str>, value: Option<Cow<str>>);
@@ -647,6 +648,55 @@ fn mime_from_upload_path<'a>(request: &'a RequestInfo, path: &str) -> Option<&'a
 fn mime_guess_from_filename(filename: &str) -> mime_guess::Mime {
     let maybe_mime = mime_guess::from_path(filename).first();
     maybe_mime.unwrap_or(mime::APPLICATION_OCTET_STREAM)
+}
+
+/// Returns a string containing a JSON-encoded match object, or `null` if no match was found.
+/// The match object contains one key per capture group, with the value being the matched text.
+/// For named capture groups (`(?<name>pattern)`), the key is the name.
+/// For unnamed capture groups (`(pattern)`), the key is the index of the capture group as a string.
+async fn regex_match<'a>(
+    pattern: Cow<'a, str>,
+    text: Option<Cow<'a, str>>,
+) -> Result<Option<String>, anyhow::Error> {
+    use serde::{ser::SerializeMap, Serializer};
+    let regex = regex::Regex::new(&pattern)?;
+    let Some(text) = text else {
+        return Ok(None);
+    };
+    let Some(match_obj) = regex.captures(&text) else {
+        return Ok(None);
+    };
+    let mut result = Vec::with_capacity(64);
+    let mut ser = serde_json::Serializer::new(&mut result);
+    let mut map = ser.serialize_map(Some(match_obj.len()))?;
+    for (idx, maybe_name) in regex.capture_names().enumerate() {
+        if let Some(match_group) = match_obj.get(idx) {
+            if let Some(name) = maybe_name {
+                map.serialize_entry(name, match_group.as_str())?;
+            } else {
+                let key = idx.to_string();
+                map.serialize_entry(&key, match_group.as_str())?;
+            }
+        }
+    }
+    map.end()?;
+    Ok(Some(String::from_utf8(result)?))
+}
+
+#[tokio::test]
+async fn regex_match_serializes_named_and_unnamed_groups() {
+    use std::borrow::Cow;
+    let result = regex_match(
+        Cow::Borrowed(r"(?<word>foo)(bar)"),
+        Some(Cow::Borrowed("_foobar_")),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        result.as_deref(),
+        Some(r#"{"0":"foobar","word":"foo","2":"bar"}"#)
+    );
 }
 
 async fn request_method(request: &RequestInfo) -> String {

--- a/tests/sql_test_files/data/regex_match_routing.sql
+++ b/tests/sql_test_files/data/regex_match_routing.sql
@@ -1,5 +1,5 @@
 set route = sqlpage.regex_match(
-    '/categories/(?<category>\w+)/post/(?<id>\d+)',
+    '/categories/(?<category>[A-Za-z0-9_]+)/post/(?<id>[0-9]+)',
     '/categories/sql/post/42'
 );
 

--- a/tests/sql_test_files/data/regex_match_routing.sql
+++ b/tests/sql_test_files/data/regex_match_routing.sql
@@ -1,0 +1,8 @@
+set route = sqlpage.regex_match(
+    '/categories/(?<category>\w+)/post/(?<id>\d+)',
+    '/categories/sql/post/42'
+);
+
+select
+    '{"0":"/categories/sql/post/42","category":"sql","id":"42"}' as expected,
+    $route as actual;


### PR DESCRIPTION

`sqlpage.regex_match`
---

Matches a text value against a regular expression and returns the capture groups as a JSON object.

If the text matches the pattern, the result contains one entry for each capture group that matched:
- key `0` contains the full match
- named groups like `(?<name>...)` use their name as the JSON key
- unnamed groups like `( ... )` use their numeric index as a string

If the text does not match, this function returns `NULL`.

### Example: custom routing from `404.sql`

This function is especially useful in a custom [`404.sql` page](/your-first-sql-website/custom_urls.sql),
where you want to turn a dynamic URL into variables your SQL can use.

For example, suppose you want `/categories/{category}/post/{id}` URLs such as `/categories/sql/post/42`,
but there is no physical `categories/sql/post/42.sql` file on disk.
You can put a `categories/404.sql` file in your project and extract the dynamic parts from the URL:

#### `categories/404.sql`
```sql
set route = sqlpage.regex_match(
  '/categories/(?<category>\w+)/post/(?<id>\d+)',
  sqlpage.path()
);

select 'redirect' as component, '/404' as link where $route is null;

select 'text' as component;
select '
Category: ' || ($route->>'category') || '
Post id: ' || ($route->>'id') 
  as contents;
```

If the current path is `/categories/sql/post/42`, `sqlpage.regex_match()` returns:

```json
{"0":"/categories/sql/post/42","category":"sql","id":"42"}
```

You can then use those extracted values to query your database:

```sql
select title, body
from posts
where category = $route->>'category'
  and id = cast($route->>'id' as integer);
```

### Details

- Quick regex reminder:
- `\w+` matches one or more "word" characters
- `\d+` matches one or more digits
- `(?<name>...)` creates a named capture group
- In SQLite, PostgreSQL, and some other databases, you can read fields from the returned JSON with `->` and `->>`
- On databases that do not support that syntax, use their JSON extraction function instead, such as `json_extract($route, ''$.category'')`
- For the full regular expression syntax supported by SQLPage, see the Rust `regex` crate documentation:
  [regex syntax reference](https://docs.rs/regex/latest/regex/#syntax)
- If the input text is `NULL`, the function returns `NULL`
- If an optional capture group does not match, that key is omitted from the JSON object
- If the regular expression is invalid, SQLPage returns an error

The returned JSON can then be processed with your database''s JSON functions.