### PR TITLE
Fix DuckDB :: casting warning

### DIFF
--- a/src/webserver/database/sql/parameter_extraction.rs
+++ b/src/webserver/database/sql/parameter_extraction.rs
@@ -572,6 +572,7 @@ impl VisitorMut for ParameterExtractor {
                 ..
             } if ![
                 SupportedDatabase::Postgres,
+                SupportedDatabase::Duckdb,
                 SupportedDatabase::Snowflake,
                 SupportedDatabase::Generic,
             ]


### PR DESCRIPTION
DuckDB natively supports PostgreSQL's `::` casting shorthand ([docs](https://duckdb.org/docs/stable/sql/expressions/cast#explicit-casting)), but SQLPage was warning users and transforming it to `CAST()`.

This adds `SupportedDatabase::Duckdb` to the allow-list alongside Postgres, Snowflake, and Generic to prevent the unnecessary warning and transformation.

Fixes #1200