### PR TITLE
Fix database-specific example SQL

### DIFF
--- a/examples/microsoft sql server advanced forms/survey.sql
+++ b/examples/microsoft sql server advanced forms/survey.sql
@@ -5,23 +5,16 @@ FROM questions;
 -- Save all the answers to the database, whatever the number and id of the questions
 INSERT INTO survey_answers (question_id, answer)
 SELECT
-    question_id,
-    json_unquote(
-        json_extract(
-            sqlpage.variables('post'),
-            concat('$."', question_id, '"')
-        )
-    )
-FROM json_table(
-    json_keys(sqlpage.variables('post')),
-    '$[*]' columns (question_id int path '$')
-) as question_ids;
+    TRY_CONVERT(int, answers.[key]) as question_id,
+    answers.value as answer
+FROM OPENJSON(sqlpage.variables('post')) as answers
+WHERE TRY_CONVERT(int, answers.[key]) IS NOT NULL;
 
 -- Show the answers
 select 'card' as component, 'Survey results' as title;
 select
     questions.question_text as title,
     survey_answers.answer as description,
-    'On ' || survey_answers.timestamp as footer
+    'On ' + CONVERT(varchar(33), survey_answers.timestamp, 126) as footer
 from survey_answers
 inner join questions on questions.id = survey_answers.question_id;

--- a/examples/mysql json handling/index.sql
+++ b/examples/mysql json handling/index.sql
@@ -1,10 +1,10 @@
 select 'form' as component, 'Create a new Group' as title, 'Create' as validate;
 select 'Name' as name;
 
-insert into groups(name) select :Name where :Name is not null;
+insert into `groups`(name) select :Name where :Name is not null;
 
 select 'list' as component, 'Groups' as title, 'No group yet' as empty_title;
-select name as title from groups;
+select name as title from `groups`;
 
 select 'form' as component, 'Add a user' as title, 'Add' as validate;
 select 'UserName' as name, 'Name' as label;
@@ -15,7 +15,7 @@ select
     TRUE     as multiple,
     'press ctrl to select multiple values' as description,
     json_arrayagg(json_object("label", name, "value", id)) as options
-from groups;
+from `groups`;
 
 insert into users(name) select :UserName where :UserName is not null;
 insert into group_members(group_id, user_id)
@@ -28,8 +28,8 @@ where :Memberships is not null;
 select 'list' as component, 'Users' as title, 'No user yet' as empty_title;
 select
     users.name as title,
-    group_concat(groups.name) as description
+    group_concat(`groups`.name) as description
 from users
 left join group_members on users.id = group_members.user_id
-left join groups on groups.id = group_members.group_id
+left join `groups` on `groups`.id = group_members.group_id
 group by users.id, users.name;

--- a/examples/mysql json handling/sqlpage/migrations/0001_users_and_groups.sql
+++ b/examples/mysql json handling/sqlpage/migrations/0001_users_and_groups.sql
@@ -3,7 +3,7 @@ create table users (
     name varchar(255) not null
 );
 
-create table groups (
+create table `groups` (
     id int primary key auto_increment,
     name varchar(255) not null
 );
@@ -12,6 +12,6 @@ create table group_members (
     group_id int not null,
     user_id int not null,
     primary key (group_id, user_id),
-    foreign key (group_id) references groups (id),
+    foreign key (group_id) references `groups` (id),
     foreign key (user_id) references users (id)
 );

--- a/examples/mysql json handling/survey.sql
+++ b/examples/mysql json handling/survey.sql
@@ -22,6 +22,6 @@ select 'card' as component, 'Survey results' as title;
 select
     questions.question_text as title,
     survey_answers.answer as description,
-    'On ' || survey_answers.timestamp as footer
+    CONCAT('On ', survey_answers.timestamp) as footer
 from survey_answers
 inner join questions on questions.id = survey_answers.question_id;

--- a/examples/nginx/website/add_comment.sql
+++ b/examples/nginx/website/add_comment.sql
@@ -1,2 +1,2 @@
 INSERT INTO comments (post_id, user_id, content) VALUES ($id, 1, :content);
-SELECT 'redirect' as component, '/post/' || $id AS link;
+SELECT 'redirect' as component, CONCAT('/post/', $id) AS link;

--- a/examples/nginx/website/index.sql
+++ b/examples/nginx/website/index.sql
@@ -4,7 +4,7 @@ SELECT
     p.title,
     u.username AS description,
     'user' AS icon,
-    '/post/' || p.id AS link
+    CONCAT('/post/', p.id) AS link
 FROM posts p
 JOIN users u ON p.user_id = u.id
 ORDER BY p.created_at DESC;

--- a/examples/nginx/website/post.sql
+++ b/examples/nginx/website/post.sql
@@ -37,7 +37,7 @@ SELECT 'divider' as component;
 SELECT 'form' as component,
        'Add a comment' as title,
        'Post comment' as validate,
-       '/add_comment.sql?id=' || $id as action;
+       CONCAT('/add_comment.sql?id=', $id) as action;
 
 SELECT 'textarea' as type,
        'content' as name,

--- a/examples/web servers - apache/website/index.sql
+++ b/examples/web servers - apache/website/index.sql
@@ -1,9 +1,9 @@
 select
     'text' as component,
     true as article,
-    '
+    CONCAT('
 # Welcome to my website
 
-Using SQLPage v' || sqlpage.version() || '
+Using SQLPage v', sqlpage.version(), '
 
-Connected to **MySQL** v' || version () as contents_md;
+Connected to **MySQL** v', version ()) as contents_md;

--- a/tests/data_formats/csv_data_mssql.sql
+++ b/tests/data_formats/csv_data_mssql.sql
@@ -8,4 +8,4 @@ select
 union all
 select
     1 as id,
-    CONCAT(N'Tu gères ', NCHAR(39), NCHAR(59), NCHAR(39), N' et ', NCHAR(39), NCHAR(34), NCHAR(39), N' ?') as msg;
+    CONCAT(N'Tu gères ', NCHAR(39), N';', NCHAR(39), N' et ', NCHAR(39), N'"', NCHAR(39), N' ?') as msg;

--- a/tests/data_formats/csv_data_mssql.sql
+++ b/tests/data_formats/csv_data_mssql.sql
@@ -1,0 +1,11 @@
+select
+    N'csv' as component,
+    N';' as separator;
+
+select
+    0 as id,
+    N'Hello World !' as msg
+union all
+select
+    1 as id,
+    CONCAT(N'Tu gères ', NCHAR(39), NCHAR(59), NCHAR(39), N' et ', NCHAR(39), NCHAR(34), NCHAR(39), N' ?') as msg;

--- a/tests/data_formats/mod.rs
+++ b/tests/data_formats/mod.rs
@@ -49,7 +49,15 @@ async fn test_csv_body() -> actix_web::Result<()> {
         return Ok(());
     }
 
-    let req = crate::common::get_request_to_with_data("/tests/data_formats/csv_data.sql", app_data)
+    let csv_test_file = if matches!(
+        app_data.db.info.database_type,
+        sqlpage::webserver::database::SupportedDatabase::Mssql
+    ) {
+        "/tests/data_formats/csv_data_mssql.sql"
+    } else {
+        "/tests/data_formats/csv_data.sql"
+    };
+    let req = crate::common::get_request_to_with_data(csv_test_file, app_data)
         .await?
         .to_srv_request();
     let resp = main_handler(req).await?;


### PR DESCRIPTION
This splits out dialect fixes that are useful independently from the SQLx driver migration PR.\n\nChanges:\n- Use MySQL CONCAT/backticks in MySQL-backed examples.\n- Use SQL Server OPENJSON and string conversion in the MSSQL survey example.\n- Add an MSSQL-specific CSV response fixture where string literal/concatenation syntax differs.\n\nValidation:\n- cargo fmt --all\n- cargo test data_formats::test_csv_body