### PR TITLE
Exclude attacker-planted-cookie attacks from the threat model

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -135,6 +135,13 @@ SQLPage vulnerabilities:
   needs.
 - A SQLPage application is publicly reachable because no authentication was
   configured.
+- An attacker can plant or overwrite cookies for the SQLPage origin (for
+  example through a compromised subdomain, a sibling application on a shared
+  parent domain, or a man-in-the-middle on plain HTTP). Attacks that depend on
+  injecting attacker-chosen cookies into the victim's browser, such as OIDC
+  login CSRF or session fixation via a forged login-flow-state cookie, are out
+  of scope. SQLPage assumes its origin's cookie jar is writable only by the
+  user agent, not by attackers.
 - Trusted SQL asks SQLPage or the database to perform expensive work.
 
 These may still be serious and should be fixed in the affected application,


### PR DESCRIPTION
Documents that attacks requiring the attacker to write cookies into the victim's browser are out of scope.

This is the precondition behind the OIDC login-CSRF / session-fixation class (forged `sqlpage_oidc_state_*` cookie). Signing the cookie does not close it (an attacker can copy a validly server-signed cookie from their own flow), and a server-side one-time state store does not either (the attacker's state is validly issued and consumed once by the victim). The realistic defense is cookie-injection hardening, but defending against an attacker who can already write cookies to the exact origin is not something SQLPage can guarantee.

Adds one bullet to the Out of Scope list in [`SECURITY.md`](https://github.com/sqlpage/SQLPage/blob/ophir.lojkine/security-exclude-cookie-planting/SECURITY.md). Docs only.