### PR TITLE
Use source mtime for Last-Modified and unify modified-since semantics

### DIFF
--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -36,6 +36,32 @@ impl FileSystem {
         }
     }
 
+    pub async fn last_modified(
+        &self,
+        app_state: &AppState,
+        path: &Path,
+        priviledged: bool,
+    ) -> anyhow::Result<DateTime<Utc>> {
+        let local_path = self.safe_local_path(app_state, path, priviledged)?;
+        let local_result = tokio::fs::metadata(&local_path)
+            .await
+            .and_then(|metadata| metadata.modified())
+            .map(DateTime::<Utc>::from);
+        match (local_result, &self.db_fs_queries) {
+            (Ok(last_modified), _) => Ok(last_modified),
+            (Err(e), Some(db_fs)) if is_path_missing_error(&e) => {
+                db_fs.last_modified_in_db(app_state, path).await
+            }
+            (Err(e), _) => {
+                let status = io_error_status(&e)
+                    .unwrap_or(actix_web::http::StatusCode::INTERNAL_SERVER_ERROR);
+                Err(e).with_status(status).with_context(|| {
+                    format!("Unable to read local file metadata for {}", path.display())
+                })
+            }
+        }
+    }
+
     pub async fn modified_since(
         &self,
         app_state: &AppState,
@@ -258,6 +284,7 @@ pub struct DbFsQueries {
     was_modified: AnyStatement<'static>,
     read_file: AnyStatement<'static>,
     exists: AnyStatement<'static>,
+    last_modified: AnyStatement<'static>,
 }
 
 impl DbFsQueries {
@@ -286,6 +313,7 @@ impl DbFsQueries {
             was_modified: Self::make_was_modified_query(db).await?,
             read_file: Self::make_read_file_query(db).await?,
             exists: Self::make_exists_query(db).await?,
+            last_modified: Self::make_last_modified_query(db).await?,
         })
     }
 
@@ -300,7 +328,7 @@ impl DbFsQueries {
 
     async fn make_was_modified_query(db: &Database) -> anyhow::Result<AnyStatement<'static>> {
         let was_modified_query = format!(
-            "SELECT 1 from sqlpage_files WHERE last_modified >= {} AND path = {}",
+            "SELECT 1 from sqlpage_files WHERE last_modified > {} AND path = {}",
             make_placeholder(db.info.kind, 1),
             make_placeholder(db.info.kind, 2)
         );
@@ -329,6 +357,39 @@ impl DbFsQueries {
         );
         let param_types: &[AnyTypeInfo; 1] = &[<str as Type<Postgres>>::type_info().into()];
         db.prepare_with(&exists_query, param_types).await
+    }
+
+    async fn make_last_modified_query(db: &Database) -> anyhow::Result<AnyStatement<'static>> {
+        let last_modified_query = format!(
+            "SELECT last_modified from sqlpage_files WHERE path = {}",
+            make_placeholder(db.info.kind, 1),
+        );
+        let param_types: &[AnyTypeInfo; 1] = &[<str as Type<Postgres>>::type_info().into()];
+        db.prepare_with(&last_modified_query, param_types).await
+    }
+
+    async fn last_modified_in_db(
+        &self,
+        app_state: &AppState,
+        path: &Path,
+    ) -> anyhow::Result<DateTime<Utc>> {
+        self.last_modified
+            .query_as::<(DateTime<Utc>,)>()
+            .bind(path.display().to_string())
+            .fetch_optional(&app_state.db.connection)
+            .await
+            .map_err(anyhow::Error::from)
+            .and_then(|last_modified| {
+                last_modified
+                    .map(|(last_modified,)| last_modified)
+                    .ok_or_else(|| {
+                        ErrorWithStatus {
+                            status: actix_web::http::StatusCode::NOT_FOUND,
+                        }
+                        .into()
+                    })
+            })
+            .with_context(|| format!("Unable to get the modification time of {}", path.display()))
     }
 
     async fn file_modified_since_in_db(
@@ -473,6 +534,17 @@ async fn test_sql_file_read_utf8() -> anyhow::Result<()> {
     assert!(
         !was_modified,
         "File should not be modified since one hour in the future"
+    );
+
+    let last_modified = fs
+        .last_modified(&state, "unit test file.txt".as_ref(), false)
+        .await?;
+    let was_modified = fs
+        .modified_since(&state, "unit test file.txt".as_ref(), last_modified, false)
+        .await?;
+    assert!(
+        !was_modified,
+        "A file should not be considered modified since its exact modification time"
     );
 
     Ok(())

--- a/src/webserver/http.rs
+++ b/src/webserver/http.rs
@@ -33,14 +33,12 @@ use crate::webserver::routing::RoutingAction::{
 use crate::webserver::routing::{AppFileStore, calculate_route};
 use actix_web::body::MessageBody;
 use anyhow::{Context, bail};
-use chrono::{DateTime, Utc};
 use futures_util::StreamExt;
 use futures_util::stream::Stream;
 use std::borrow::Cow;
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::Arc;
-use std::time::SystemTime;
 use tokio::sync::mpsc;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -441,17 +439,19 @@ async fn serve_file(
     if_modified_since: Option<IfModifiedSince>,
 ) -> actix_web::Result<HttpResponse> {
     let path = strip_site_prefix(path, state);
-    if let Some(IfModifiedSince(date)) = if_modified_since {
-        let since = DateTime::<Utc>::from(SystemTime::from(date));
-        let modified = state
-            .file_system
-            .modified_since(state, path.as_ref(), since, false)
-            .await
-            .with_context(|| format!("Unable to get modification time of file {path:?}"))
-            .map_err(|e| anyhow_err_to_actix(e, state))?;
-        if !modified {
-            return Ok(HttpResponse::NotModified().finish());
-        }
+    let last_modified = state
+        .file_system
+        .last_modified(state, path.as_ref(), false)
+        .await
+        .with_context(|| format!("Unable to get modification time of file {path:?}"))
+        .map_err(|e| anyhow_err_to_actix(e, state))?;
+    let last_modified = HttpDate::from(last_modified.into());
+    if let Some(IfModifiedSince(date)) = if_modified_since
+        && last_modified <= date
+    {
+        return Ok(HttpResponse::NotModified()
+            .insert_header(LastModified(last_modified))
+            .finish());
     }
     state
         .file_system
@@ -466,7 +466,7 @@ async fn serve_file(
                         .first()
                         .map_or_else(ContentType::octet_stream, ContentType),
                 )
-                .insert_header(LastModified(HttpDate::from(SystemTime::now())))
+                .insert_header(LastModified(last_modified))
                 .body(b)
         })
 }

--- a/tests/requests/mod.rs
+++ b/tests/requests/mod.rs
@@ -248,3 +248,43 @@ async fn test_missing_multipart_content_disposition_returns_bad_request() -> act
 }
 
 mod webhook_hmac;
+
+#[actix_web::test]
+async fn static_file_uses_source_last_modified_for_revalidation() -> anyhow::Result<()> {
+    use actix_web::http::header;
+    use actix_web::http::header::HttpDate;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    let unique = SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos();
+    let web_root = std::env::temp_dir().join(format!("sqlpage-last-modified-{unique}"));
+    std::fs::create_dir_all(&web_root)?;
+    let asset_path = web_root.join("asset.txt");
+    std::fs::write(&asset_path, "hello static world\n")?;
+
+    let expected = HttpDate::from(std::fs::metadata(&asset_path)?.modified()?);
+    let mut config = crate::common::test_config();
+    config.web_root = web_root.clone();
+    let app_data = crate::common::make_app_data_from_config(config).await;
+
+    let req = crate::common::get_request_to_with_data("/asset.txt", app_data.clone())
+        .await?
+        .to_srv_request();
+    let response = main_handler(req).await?;
+    assert_eq!(response.status(), StatusCode::OK);
+    let last_modified = response
+        .headers()
+        .get(header::LAST_MODIFIED)
+        .expect("static files should have a Last-Modified header")
+        .to_str()?;
+    assert_eq!(last_modified, expected.to_string());
+
+    let req = crate::common::get_request_to_with_data("/asset.txt", app_data)
+        .await?
+        .insert_header((header::IF_MODIFIED_SINCE, last_modified))
+        .to_srv_request();
+    let response = main_handler(req).await?;
+    assert_eq!(response.status(), StatusCode::NOT_MODIFIED);
+
+    std::fs::remove_dir_all(web_root)?;
+    Ok(())
+}


### PR DESCRIPTION
### Motivation

- Static files were served with `Last-Modified: now`, which changes on every request and prevents meaningful cache revalidation. 
- The filesystem backends used different comparison contracts (local `>` vs DB `>=`), causing inconsistent conditional-request behavior. 
- Returning the real source mtime and using a single comparison rule improves caching correctness and client revalidation.

### Description

- Added `FileSystem::last_modified` which returns the real modification time from the local filesystem or the `last_modified` column in the DB-backed `sqlpage_files` table. 
- Added DB support for fetching the `last_modified` value (`make_last_modified_query` and `last_modified_in_db`) and changed the DB `was_modified` check to strict `>` to match local semantics. 
- Updated `serve_file` to compute `last_modified`, use it for `If-Modified-Since` validation, and insert the same `Last-Modified` value on both `200 OK` and `304 Not Modified` responses. 
- Added regression coverage: a test that static files expose the source `Last-Modified` and revalidate correctly, and an assertion in the DB test that a file is not considered modified since its exact timestamp. 
- Closes https://github.com/sqlpage/SQLPage/issues/1323

### Testing

- Ran formatting checks with `cargo fmt --all` and `cargo fmt --all -- --check`, and verified `git diff --check`; these passed. 
- Attempted `cargo clippy --all-targets --all-features -- -D warnings`, but it was blocked by the environment `libsqlite3-sys 0.38.1` build error using the unstable `cfg_select` feature with the installed `rustc`. 
- Attempted `cargo test` and running the new `static_file_uses_source_last_modified_for_revalidation` test, but test execution was blocked by the same `libsqlite3-sys` build error. 
- The code was formatted and checked; running the full test suite and clippy should succeed once the build environment is using a toolchain compatible with `libsqlite3-sys` (or the dependency is adjusted).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2bfd47b6748331beac1fd64dfc72fa)