### PR TITLE
Fix Docker latest tag for DuckDB variant

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -525,7 +525,7 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY_IMAGE }}
-          flavor: suffix=${{ matrix.variant != 'minimal' && format('-{0}', matrix.variant) || '' }}
+          flavor: suffix=${{ matrix.variant != 'minimal' && format('-{0}', matrix.variant) || '' }},onlatest=true
       - name: Login to Docker Hub
         uses: docker/login-action@v4
         with:


### PR DESCRIPTION
## Summary

- Make the Docker metadata suffix apply to the `latest` tag in the manifest publishing job.
- Keeps the existing minimal tags unsuffixed and DuckDB tags suffixed.

## Why

`docker/metadata-action` handles `latest` specially. The existing `suffix=-duckdb` produced suffixed version tags such as `v0.44.1-duckdb`, but did not suffix `latest`, so the DuckDB manifest could publish `lovasoa/sqlpage:latest`.

With `onlatest=true`, tag pushes should produce:

- minimal: `vX.Y.Z`, `latest`
- DuckDB: `vX.Y.Z-duckdb`, `latest-duckdb`

## Validation

- `git diff --check -- .github/workflows/ci.yml`
- `actionlint -shellcheck '' .github/workflows/ci.yml`

I also ran plain `actionlint .github/workflows/ci.yml`; it reports an existing shellcheck warning in the manifest creation script, unrelated to this metadata-line change.