### PR TITLE
Fix typo in shell documentation

### DIFF
--- a/examples/official-site/sqlpage/migrations/01_documentation.sql
+++ b/examples/official-site/sqlpage/migrations/01_documentation.sql
@@ -1346,7 +1346,7 @@ INSERT INTO parameter(component, name, description, type, top_level, optional) S
     ('rtl', 'Whether the page should be displayed in right-to-left mode. Used to display Arabic, Hebrew, Persian, etc.', 'BOOLEAN', TRUE, TRUE),
     ('refresh', 'Number of seconds after which the page should refresh. This can be useful to display dynamic content that updates automatically.', 'INTEGER', TRUE, TRUE),
     ('sidebar', 'Whether the menu defined by menu_item should be displayed on the left side of the page instead of the top. Introduced in v0.27.', 'BOOLEAN', TRUE, TRUE),
-    ('sidebar_theme', 'Used with sidebar property, It can be set to "dark" to exclusively set the sidebar into dark theme.', 'BOOLEAN', TRUE, TRUE),
+    ('sidebar_theme', 'Used with sidebar property, It can be set to "dark" to exclusively set the sidebar into dark theme.', 'TEXT', TRUE, TRUE),
     ('theme', 'Set to "dark" to use a dark theme.', 'TEXT', TRUE, TRUE),
     ('footer', 'Muted text to display in the footer of the page. This can be used to display a link to the terms and conditions of your application, for instance. By default, shows "Built with SQLPage". Supports links with markdown.', 'TEXT', TRUE, TRUE),
     ('preview_image', 'The URL of an image to display as a link preview when the page is shared on social media', 'URL', TRUE, TRUE),


### PR DESCRIPTION
I found a typo in [shell documentation](https://sql-page.com/component.sql?component=shell), sidebar_theme must be TEXT (like theme parameter) and contain **light** or **dark**.

<img width="1196" height="153" alt="image" src="https://github.com/user-attachments/assets/ad9f80b8-79d0-4106-b449-5575c4219e43" />

<img width="986" height="170" alt="image" src="https://github.com/user-attachments/assets/80f096d3-e67a-4d10-90d9-c456d64d5bc2" />

Regards,