### PR TITLE
Prevent caching OIDC redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## unreleased
 
 - **Access logs now go to stdout.** SQLPage now writes the single per-request completion log line to stdout with the target `sqlpage::access`, matching common application-server and container logging conventions. Diagnostic logs, warnings, and internal errors still go to stderr. If your `LOG_LEVEL` or `RUST_LOG` filter is scoped to a specific old target such as `sqlpage::webserver::http=info`, add `sqlpage::access=info` so request-completion logs are still emitted. If your log pipeline only collects stderr, update it to collect stdout too.
+- **OIDC redirects are no longer cacheable.** Authorization redirects contain one-time state and post-login redirects set session cookies. SQLPage now sends `Cache-Control: no-store` for these responses, preventing a browser or intermediary from replaying an expired authorization redirect.
 
 ## v0.44.1
 

--- a/src/webserver/oidc.rs
+++ b/src/webserver/oidc.rs
@@ -870,6 +870,9 @@ fn build_auth_provider_redirect_response(
     .finish();
     let mut response = HttpResponse::SeeOther();
     response.append_header((header::LOCATION, url.to_string()));
+    // The location contains a one-time CSRF state. A cached redirect would
+    // replay it after its state cookie has been consumed.
+    response.append_header((header::CACHE_CONTROL, "no-store"));
     if let Ok(cookies) = request.cookies() {
         for mut cookie in get_tmp_login_flow_state_cookies_to_evict(&cookies).cloned() {
             cookie.make_removal();
@@ -884,6 +887,7 @@ fn build_auth_provider_redirect_response(
 fn build_redirect_response(target_url: String) -> HttpResponse {
     HttpResponse::SeeOther()
         .append_header(("Location", target_url))
+        .append_header((header::CACHE_CONTROL, "no-store"))
         .body("Redirecting...")
 }
 

--- a/tests/oidc/mod.rs
+++ b/tests/oidc/mod.rs
@@ -265,9 +265,9 @@ fn get_query_param(url: &Url, name: &str) -> String {
 }
 
 fn permits_storage_after_proxy_adds_freshness(headers: &header::HeaderMap) -> bool {
-    // The supplied HAR has `Cache-Control: max-age=86400` on the OIDC 303s,
-    // despite SQLPage not setting it. This models a proxy adding that directive:
-    // `no-store` still wins when both directives are present.
+    // Reproduces https://github.com/sqlpage/SQLPage/issues/1341, where an
+    // intermediary added `Cache-Control: max-age=86400` to OIDC 303 responses.
+    // `no-store` must still prevent browser storage when both directives exist.
     !headers
         .get_all(header::CACHE_CONTROL)
         .filter_map(|value| value.to_str().ok())
@@ -341,8 +341,9 @@ async fn test_oidc_cached_authorization_redirect_cannot_replay_consumed_state() 
     let (app, provider) = setup_oidc_test(|_| {}).await;
     let mut cookies: Vec<Cookie<'static>> = Vec::new();
 
-    // Chrome's private cache can replay a cached 303 without reapplying its
-    // Set-Cookie headers. This is the sequence captured in #1341's HAR.
+    // Reproduces https://github.com/sqlpage/SQLPage/issues/1341: Chrome's
+    // private cache can replay a cached 303 without reapplying Set-Cookie
+    // headers, causing the browser to retry an already-consumed OIDC state.
     let initial_response = request_with_cookies!(app, test::TestRequest::get().uri("/"), cookies);
     let initial_auth_url = Url::parse(
         initial_response

--- a/tests/oidc/mod.rs
+++ b/tests/oidc/mod.rs
@@ -264,6 +264,17 @@ fn get_query_param(url: &Url, name: &str) -> String {
         .to_string()
 }
 
+fn permits_storage_after_proxy_adds_freshness(headers: &header::HeaderMap) -> bool {
+    // The supplied HAR has `Cache-Control: max-age=86400` on the OIDC 303s,
+    // despite SQLPage not setting it. This models a proxy adding that directive:
+    // `no-store` still wins when both directives are present.
+    !headers
+        .get_all(header::CACHE_CONTROL)
+        .filter_map(|value| value.to_str().ok())
+        .flat_map(|value| value.split(','))
+        .any(|directive| directive.trim().eq_ignore_ascii_case("no-store"))
+}
+
 macro_rules! request_with_cookies {
     ($app:expr, $req:expr, $cookies:expr) => {{
         let mut req = $req;
@@ -326,12 +337,78 @@ async fn setup_oidc_test(
 }
 
 #[actix_web::test]
+async fn test_oidc_cached_authorization_redirect_cannot_replay_consumed_state() {
+    let (app, provider) = setup_oidc_test(|_| {}).await;
+    let mut cookies: Vec<Cookie<'static>> = Vec::new();
+
+    // Chrome's private cache can replay a cached 303 without reapplying its
+    // Set-Cookie headers. This is the sequence captured in #1341's HAR.
+    let initial_response = request_with_cookies!(app, test::TestRequest::get().uri("/"), cookies);
+    let initial_auth_url = Url::parse(
+        initial_response
+            .headers()
+            .get(header::LOCATION)
+            .unwrap()
+            .to_str()
+            .unwrap(),
+    )
+    .unwrap();
+    let cached_authorization_url =
+        permits_storage_after_proxy_adds_freshness(initial_response.headers())
+            .then_some(initial_auth_url.clone());
+
+    let state = get_query_param(&initial_auth_url, "state");
+    let nonce = get_query_param(&initial_auth_url, "nonce");
+    let redirect_uri = get_query_param(&initial_auth_url, "redirect_uri");
+    let callback_path = Url::parse(&redirect_uri).unwrap().path().to_owned();
+    provider.store_auth_code("first-code".to_string(), nonce.clone());
+    let callback_uri = format!("{callback_path}?code=first-code&state={state}");
+    let callback_response =
+        request_with_cookies!(app, test::TestRequest::get().uri(&callback_uri), cookies);
+    assert_eq!(callback_response.status(), StatusCode::SEE_OTHER);
+
+    if let Some(stale_authorization_url) = cached_authorization_url {
+        // A fresh Entra code is returned for the authorization URL cached by
+        // Chrome, but its state is the state that the successful callback just
+        // consumed. Before this fix, SQLPage restarted OIDC here, creating the
+        // observed redirect loop.
+        let stale_state = get_query_param(&stale_authorization_url, "state");
+        provider.store_auth_code("stale-code".to_string(), nonce);
+        let stale_callback_uri = format!("{callback_path}?code=stale-code&state={stale_state}");
+        let stale_callback_response = request_with_cookies!(
+            app,
+            test::TestRequest::get().uri(&stale_callback_uri),
+            cookies
+        );
+        panic!(
+            "a cacheable authorization redirect replays a consumed state; stale callback redirected to {}",
+            stale_callback_response
+                .headers()
+                .get(header::LOCATION)
+                .unwrap()
+                .to_str()
+                .unwrap()
+        );
+    }
+
+    // With `no-store`, Chrome re-requests `/` after login and sends its new
+    // auth cookie instead of following the original authorization redirect.
+    let final_response = request_with_cookies!(app, test::TestRequest::get().uri("/"), cookies);
+    assert_eq!(final_response.status(), StatusCode::OK);
+}
+
+#[actix_web::test]
 async fn test_oidc_happy_path() {
     let (app, provider) = setup_oidc_test(|_| {}).await;
     let mut cookies: Vec<Cookie<'static>> = Vec::new();
 
     let resp = request_with_cookies!(app, test::TestRequest::get().uri("/"), cookies);
     assert_eq!(resp.status(), StatusCode::SEE_OTHER);
+    assert_eq!(
+        resp.headers().get(header::CACHE_CONTROL).unwrap(),
+        "no-store",
+        "the authorization redirect contains a one-time state and must not be cached"
+    );
     let auth_url = Url::parse(resp.headers().get("location").unwrap().to_str().unwrap()).unwrap();
 
     let state = get_query_param(&auth_url, "state");
@@ -347,6 +424,11 @@ async fn test_oidc_happy_path() {
     let callback_resp =
         request_with_cookies!(app, test::TestRequest::get().uri(&callback_uri), cookies);
     assert_eq!(callback_resp.status(), StatusCode::SEE_OTHER);
+    assert_eq!(
+        callback_resp.headers().get(header::CACHE_CONTROL).unwrap(),
+        "no-store",
+        "the post-login redirect must not re-enter a cached authorization redirect"
+    );
 
     let final_resp = request_with_cookies!(app, test::TestRequest::get().uri("/"), cookies);
     assert_eq!(final_resp.status(), StatusCode::OK);


### PR DESCRIPTION
Fixes #1341.

## Reproduction

The supplied Chrome HAR makes the loop deterministic without Android:

1. The response for `GET /` is a `303` to Entra containing state `S`. It has `Cache-Control: max-age=86400` and an `Expires` value one day later.
2. Chrome stores that redirect. After the callback for `S` succeeds, SQLPage removes `sqlpage_oidc_state_S` and redirects to `/`.
3. Chrome serves the cached `303` for `/`, rather than requesting SQLPage. It follows the old Entra authorization URL, which returns a fresh code but the same state `S`.
4. The callback cannot find the consumed state cookie, so SQLPage starts another login. Its fresh callback succeeds and redirects to `/`, returning to step 3.

The HAR proves the cache reuse: entries at 22:52:41, 22:52:43, 22:52:44, and 22:52:45 all redirect to the identical authorization URL/state `Ohcyc0-izJdjD6uGl0zFkg`, while their response `Date` is 22:51:03. The final navigation sends `Cache-Control: max-age=0`, bypasses the stale redirect, and succeeds. The HAR is from desktop Chrome 150.

I also reproduced this with a local app/IdP and a real Chrome 150 persistent profile: marking the state-bearing `303` as `max-age=86400` produces `net::ERR_TOO_MANY_REDIRECTS`; changing only that header to `no-store` completes authentication normally.

## Fix

Send `Cache-Control: no-store` on OIDC authorization and post-login redirects. Deployments should also ensure Apache/CDN configuration does not overwrite this directive or cache redirects / responses with `Set-Cookie`.

`test_oidc_cached_authorization_redirect_cannot_replay_consumed_state` is an integration-level reproduction of the HAR sequence. It models the observed proxy-added freshness directive and Chrome private-cache behavior: it completes a valid login, reuses the cached state-bearing authorization redirect without replaying its `Set-Cookie`, and obtains a callback with the now-consumed state. Before this change the test follows that callback to SQLPage's retry redirect and fails; with `no-store`, the browser model re-requests `/` with its auth cookie and receives `200`.

## Validation

- `cargo fmt --all`
- `cargo test --test mod oidc::`
- `cargo clippy --all-targets --all-features -- -D warnings`