### PR TITLE
Update AWS Lambda runtime to Amazon Linux 2023

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,6 +108,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - run: docker build -t sqlpage-lambda . -f lambda.Dockerfile --target runner
       - run: docker build -t sqlpage-lambda-builder . -f lambda.Dockerfile --target builder
       - run: docker run sqlpage-lambda-builder cat deploy.zip > sqlpage-aws-lambda.zip
       - uses: actions/upload-artifact@v7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## unreleased
 
- - AWS Lambda builds and documentation now use the supported Amazon Linux 2023 custom runtime instead of the end-of-life Amazon Linux 2 runtime.
+ - AWS Lambda builds and documentation now use the supported Amazon Linux 2023 custom runtime instead of the end-of-life Amazon Linux 2 runtime. Release artifacts include the configuration directory required on Lambda's read-only filesystem.
  - `sqlpage.send_mail` now supports rich email bodies. Use `body_html` for a caller-provided HTML alternative, or `body_md` to render Markdown as HTML. Messages retain a plain-text alternative; `body` may be omitted when `body_md` is used, and `body_md` and `body_html` cannot be combined.
  - Form `options_source` URLs now preserve existing query parameters when adding the dynamic `search` parameter.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+ - AWS Lambda builds and documentation now use the supported Amazon Linux 2023 custom runtime instead of the end-of-life Amazon Linux 2 runtime.
  - `sqlpage.send_mail` now supports rich email bodies. Use `body_html` for a caller-provided HTML alternative, or `body_md` to render Markdown as HTML. Messages retain a plain-text alternative; `body` may be omitted when `body_md` is used, and `body_md` and `body_html` cannot be combined.
  - Form `options_source` URLs now preserve existing query parameters when adding the dynamic `search` parameter.
 

--- a/README.md
+++ b/README.md
@@ -282,6 +282,10 @@ You can then just add your own SQL files to `sqlpage-aws-lambda.zip`,
 and [upload it to AWS Lambda](https://docs.aws.amazon.com/lambda/latest/dg/gettingstarted-package.html#gettingstarted-package-zip),
 selecting *Custom runtime on Amazon Linux 2023* (`provided.al2023`) as the runtime.
 
+The provided archive includes the empty `sqlpage` configuration directory required at startup.
+You can add a `sqlpage.json` file, custom templates, or migrations to it. Keep the directory in the
+archive because Lambda function packages are read-only and SQLPage cannot create it there.
+
 ### Hosting sql files directly inside the database
 
 When running serverless, you can include the SQL files directly in the image that you are deploying.

--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ An easy way to do so is using the provided docker image:
 
 You can then just add your own SQL files to `sqlpage-aws-lambda.zip`,
 and [upload it to AWS Lambda](https://docs.aws.amazon.com/lambda/latest/dg/gettingstarted-package.html#gettingstarted-package-zip),
-selecting *Custom runtime on Amazon Linux 2* as a runtime.
+selecting *Custom runtime on Amazon Linux 2023* (`provided.al2023`) as the runtime.
 
 ### Hosting sql files directly inside the database
 

--- a/configuration.md
+++ b/configuration.md
@@ -215,6 +215,9 @@ The configuration directory is the `./sqlpage/` folder by default.
 In the [official docker image](https://hub.docker.com/r/lovasoa/sqlpage), it is located in `/etc/sqlpage/`.
 It can be configured using the `--config-dir` command-line argument, or the `SQLPAGE_CONFIGURATION_DIRECTORY` environment variable.
 
+At startup, SQLPage creates the configuration directory when it is absent and rejects the path when it is not a directory.
+AWS Lambda release artifacts include an empty `./sqlpage` directory because deployed function packages are read-only.
+
 It can contain
 
  - the [`sqlpage.json`](#configuring-sqlpage) configuration file,

--- a/lambda.Dockerfile
+++ b/lambda.Dockerfile
@@ -12,7 +12,7 @@ RUN   mv target/release/sqlpage bootstrap && \
       size bootstrap && \
       zip -9 -r deploy.zip bootstrap index.sql
 
-FROM public.ecr.aws/lambda/provided:al2 AS runner
+FROM public.ecr.aws/lambda/provided:al2023 AS runner
 COPY --from=builder /usr/src/sqlpage/bootstrap /main
 COPY --from=builder /usr/src/sqlpage/index.sql ./index.sql
 ENTRYPOINT ["/main"]

--- a/lambda.Dockerfile
+++ b/lambda.Dockerfile
@@ -10,9 +10,11 @@ RUN cargo build --release --features lambda-web
 RUN   mv target/release/sqlpage bootstrap && \
       strip --strip-all bootstrap && \
       size bootstrap && \
-      zip -9 -r deploy.zip bootstrap index.sql
+      zip -9 -j deploy.zip bootstrap src/index.sql && \
+      zip -9 deploy.zip sqlpage/
 
 FROM public.ecr.aws/lambda/provided:al2023 AS runner
 COPY --from=builder /usr/src/sqlpage/bootstrap /main
-COPY --from=builder /usr/src/sqlpage/index.sql ./index.sql
+COPY --from=builder /usr/src/sqlpage/src/index.sql ./index.sql
+RUN mkdir -p ./sqlpage
 ENTRYPOINT ["/main"]


### PR DESCRIPTION
### Motivation

- Amazon Linux 2 has reached end-of-life, so the serverless documentation and runner image should recommend and use a supported runtime. 
- The release workflow should validate the actual runtime image used to build the Lambda ZIP to catch runtime regressions early.

### Description

- Update the serverless docs in `README.md` to recommend the Amazon Linux 2023 custom runtime (`provided.al2023`).
- Change the Lambda runner image in `lambda.Dockerfile` from `public.ecr.aws/lambda/provided:al2` to `public.ecr.aws/lambda/provided:al2023`.
- Add a release workflow step in `.github/workflows/release.yml` to build the `runner` Docker target (`docker build -t sqlpage-lambda . -f lambda.Dockerfile --target runner`) so the runtime image is validated during CI.
- Add an unreleased entry to `CHANGELOG.md` noting the runtime migration.

### Testing

- Ran `git diff --check` to validate the patch format, which succeeded.
- Parsed `.github/workflows/release.yml` with YAML (Ruby) to ensure the workflow is valid, which succeeded.
- Verified there are no remaining `provided:al2` / "Amazon Linux 2" references with `rg`, which succeeded.
- Attempted to run `cargo check --locked --features lambda-web` and local `docker build` to fully validate the Lambda build; these could not complete in the current environment because the available Rust toolchain is older than required for some build dependencies and Docker is not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6cf09b9fa88331b4ac65cae2c26b83)