### PR TITLE
fix(biome.js) :: fix remaining lint issues

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -6,7 +6,8 @@
       "!**/*.svg",
       "!examples/official-site/pgconf",
       "!tests/end-to-end/test-results",
-      "!.zed/*.json"
+      "!.zed/*.json",
+      "!.claude/*.json"
     ],
     "ignoreUnknown": true
   },

--- a/examples/CRUD - Authentication/www/css/style.css
+++ b/examples/CRUD - Authentication/www/css/style.css
@@ -1,9 +1,9 @@
 .menu_options_slim {
-  min-width: inherit !important;
+  min-width: inherit;
 }
 
 .menu_language_slim {
-  min-width: inherit !important;
+  min-width: inherit;
 }
 
 .menu_language {
@@ -11,13 +11,13 @@
 }
 
 div.dropdown-menu- {
-  min-width: inherit !important;
+  min-width: inherit;
 }
 
 a.dropdown-item- {
-  min-width: inherit !important;
+  min-width: inherit;
 }
 
 .slim_item {
-  min-width: inherit !important;
+  min-width: inherit;
 }

--- a/examples/official-site/assets/highlightjs-and-tabler-theme.css
+++ b/examples/official-site/assets/highlightjs-and-tabler-theme.css
@@ -60,8 +60,8 @@
   --tblr-red: var(--tblr-danger);
 
   /* Luminous links */
-  --tblr-link-color: hsl(212, 70%, 75%) !important; /* Star glow */
-  --tblr-link-hover-color: hsl(212, 70%, 85%) !important; /* Supernova */
+  --tblr-link-color: hsl(212, 70%, 75%); /* Star glow */
+  --tblr-link-hover-color: hsl(212, 70%, 85%); /* Supernova */
   --tblr-carousel-caption-color: var(--tblr-muted-color);
 
   /* Ethereal shadows */
@@ -241,7 +241,8 @@ pre:has(code) {
 
 @media print {
   pre:has(code) {
+    /* biome-ignore lint/complexity/noImportantStyles: .markdown pre is more specific and caps the height at 20rem */
     max-height: none !important;
-    box-shadow: none !important;
+    box-shadow: none;
   }
 }

--- a/examples/rich-text-editor/rich_text_editor.js
+++ b/examples/rich-text-editor/rich_text_editor.js
@@ -141,7 +141,7 @@ function markdownToDelta(markdown) {
  */
 function mdastToDelta(tree) {
   const delta = { ops: [] };
-  if (!tree || !tree.children) return delta;
+  if (!tree?.children) return delta;
 
   for (const node of tree.children) {
     traverseMdastNode(node, delta);
@@ -230,7 +230,6 @@ function traverseMdastNode(node, delta, attributes = {}) {
       break;
 
     case "listItem": {
-      // biome-ignore lint/correctness/noUnusedVariables: object destructuring with a spread
       const { list, ...listItemChildrenAttributes } = attributes;
 
       for (const child of node.children || []) {

--- a/sqlpage/sqlpage.css
+++ b/sqlpage/sqlpage.css
@@ -19,6 +19,7 @@ td > p {
 
 /** Removes the margin-bottom from the last element */
 .remove-bottom-margin > :last-child {
+  /* biome-ignore lint/complexity/noImportantStyles: the last child is often a tabler spacing utility such as .my-2, which is itself !important */
   margin-bottom: 0 !important;
 }
 
@@ -29,7 +30,7 @@ td > p {
 
 /* orchidjs/tom-select#712 */
 .ts-wrapper.multi .ts-control > div.active {
-  border: 1px solid transparent !important;
+  border: 1px solid transparent;
 }
 
 /* remove the ugly text highlight in the default tom-select */
@@ -55,7 +56,7 @@ code {
 
 .apexcharts-text,
 .apexcharts-datalabel {
-  fill: var(--tblr-body-color) !important;
+  fill: var(--tblr-body-color);
   font-weight: var(--tblr-body-font-weight);
 }
 
@@ -117,6 +118,7 @@ li p {
 }
 
 .leaflet-container {
+  /* biome-ignore lint/complexity/noImportantStyles: leaflet's stylesheet is injected after this one, at the same specificity */
   background: var(--tblr-active-bg) !important;
 }
 
@@ -189,7 +191,7 @@ See https://github.com/tabler/tabler/issues/2404
 }
 
 .text-black-fg {
-  color: var(--tblr-dark-fg) !important;
+  color: var(--tblr-dark-fg);
 }
 
 .toast-colored .toast-description a {

--- a/sqlpage/sqlpage.js
+++ b/sqlpage/sqlpage.js
@@ -441,7 +441,7 @@ function open_modal_for_hash() {
   const hash = window.location.hash.substring(1);
   if (!hash) return;
   const modal = document.getElementById(hash);
-  if (!modal || !modal.classList.contains("modal")) return;
+  if (!modal?.classList.contains("modal")) return;
   const bootstrap_modal =
     window.tabler.bootstrap.Modal.getOrCreateInstance(modal);
   bootstrap_modal.show();

--- a/tests/end-to-end/official-site.spec.ts
+++ b/tests/end-to-end/official-site.spec.ts
@@ -249,7 +249,6 @@ test("File upload", async ({ page }) => {
   await page.getByRole("button", { name: "Examples", exact: true }).click();
   await page.getByText("File uploads").click();
   const my_svg = '<svg><text y="20">Hello World</text></svg>';
-  // @ts-ignore
   const buffer = Buffer.from(my_svg);
   await page.getByLabel("Picture").setInputFiles({
     name: "small.svg",
@@ -307,14 +306,14 @@ test("table sorting", async ({ page }) => {
   // Test numeric sorting on id column
   await tableSection.getByRole("button", { name: "id" }).click();
   let ids = await tableSection.locator("td.id").allInnerTexts();
-  let numericIds = ids.map((id) => Number.parseInt(id));
+  let numericIds = ids.map((id) => Number.parseInt(id, 10));
   const sortedIds = [...numericIds].sort((a, b) => a - b);
   expect(numericIds).toEqual(sortedIds);
 
   // Test reverse sorting
   await tableSection.getByRole("button", { name: "id" }).click();
   ids = await tableSection.locator("td.id").allInnerTexts();
-  numericIds = ids.map((id) => Number.parseInt(id));
+  numericIds = ids.map((id) => Number.parseInt(id, 10));
   const reverseSortedIds = [...numericIds].sort((a, b) => b - a);
   expect(numericIds).toEqual(reverseSortedIds);
 
@@ -322,7 +321,7 @@ test("table sorting", async ({ page }) => {
   await tableSection.getByRole("button", { name: "Amount in stock" }).click();
   const amounts = await tableSection.locator("td.Amount").allInnerTexts();
   const numericAmounts = amounts.map((amount) =>
-    Number.parseInt(amount.replace(/[^0-9]/g, "")),
+    Number.parseInt(amount.replace(/[^0-9]/g, ""), 10),
   );
   const sortedAmounts = [...numericAmounts].sort((a, b) => a - b);
   expect(numericAmounts).toEqual(sortedAmounts);


### PR DESCRIPTION
<!-- PR title: fix(biome.js) :: fix remaining lint issues -->
<!-- commit 0c1fdb75 · 1 of 8 · base: sqlpage/SQLPage main -->

### Motivation

- `biome check .` reports 18 warnings on a clean checkout, so a warning introduced by a new change is easy to miss.
- A developer's local `.claude/settings.local.json` is checked too, and fails the run outright.

### Description

- Drop `!important` from the declarations that do not need it.
- Keep it, with a `biome-ignore` naming the reason, in the three places that do: leaflet injects its stylesheet after ours, tabler's spacing utilities are themselves `!important`, and `.markdown pre` caps the height a print rule has to override.
- Use optional chaining in `mdastToDelta` and `open_modal_for_hash`.
- Remove a `biome-ignore` for `noUnusedVariables` that no longer matches anything.
- Drop a `@ts-ignore` on a typed `Buffer.from` call, and give three `Number.parseInt` calls their radix.
- Ignore `.claude/*.json` in `biome.json`, alongside the existing `.zed/*.json`.

### Testing

- `npm test` checks 36 files and reports nothing, where the base reports 18 warnings and 3 infos.
- The browser suite passes 21 tests against a local official site.
- `no console errors on card page` fails here and on the unmodified base alike: the page loads avatars from `avatars.githubusercontent.com`, which this machine cannot verify (`ERR_CERT_AUTHORITY_INVALID`).

---

GitHub cannot base a pull request on a branch that lives in a fork, so all eight target `main` and each one carries the commits of those above it. Review and merge them in order:

1. #1366 :: **fix(biome.js) :: fix remaining lint issues** ← this PR
2. #1367 :: fix(modal) :: give modal component an accessible name
3. #1368 :: fix(map) :: ignore map coordinates that are not a pair of numbers
4. #1369 :: feat(chart) :: render column charts as bar charts
5. #1370 :: fix(chart) :: align stacked series on their X values
6. #1371 :: fix(chart) :: line series up on a category axis for every chart type
7. #1372 :: fix(npm) :: install dependencies only once at root level
8. #1373 :: feat(typescript) :: typecheck browser JavaScript in CI
