### PR TITLE
fix(rust) :: format the files `cargo fmt` could not see

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,4 @@
+# ignore commits from showing up on git diffs.
+
+# === large formatting commits ===
+# TODO :: add commit once merged into mainline

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,7 +138,7 @@ official documentation website sql tables:
 #### Project Conventions
 
 - Built-in UI component templates: `sqlpage/templates/*.handlebars`; header/control components: `src/render.rs`.
-- SQLPage functions: one `async fn` module under `src/webserver/database/sqlpage_functions/functions/`, registered with `sqlpage_functions!` in `functions.rs`.
+- SQLPage functions: one `async fn` module under `src/webserver/database/sqlpage_functions/functions/`, declared with `mod` and registered with `sqlpage_functions!` in `functions.rs`. See its [README](./src/webserver/database/sqlpage_functions/README.md).
 - [Configuration](./configuration.md): see [AppConfig](./src/app_config.rs)
 - Routing: file-based in `src/webserver/routing.rs`. Missing paths use the nearest ancestor `404.sql`; without one, HTML uses `src/default_404.sql` and other formats receive a plain-text 404.
 - Follow patterns from similar modules before introducing new abstractions.

--- a/src/webserver/database/sqlpage_functions/README.md
+++ b/src/webserver/database/sqlpage_functions/README.md
@@ -14,17 +14,20 @@ pub(super) async fn example(request: &RequestInfo, value: Option<Cow<'_, str>>) 
 }
 ```
 
-To add `sqlpage.example`, create `functions/example.rs` and add it to the
-[`sqlpage_functions!`](function_traits.rs) call in [`functions.rs`](functions.rs):
+To add `sqlpage.example`, create `functions/example.rs`, declare its module in
+[`functions.rs`](functions.rs) and add it to the [`sqlpage_functions!`](function_traits.rs) call in
+the same file:
 
 ```rust
+mod example;
+
 sqlpage_functions! {
     // ...
     example,
 }
 ```
 
-The [`sqlpage_functions!`](function_traits.rs) macro declares the modules and generates the
+The [`sqlpage_functions!`](function_traits.rs) macro generates the
 `SqlPageFunctionName` enum the SQL engine dispatches on. Per-function argument extraction, dispatch,
 and return-value conversion are handled generically in [`function_traits.rs`](function_traits.rs) by
 the `Extract`, `Handler`, and `IntoCowResult` traits. A function's argument and return types are read

--- a/src/webserver/database/sqlpage_functions/function_traits.rs
+++ b/src/webserver/database/sqlpage_functions/function_traits.rs
@@ -222,13 +222,9 @@ impl<'a, T: IntoCow<'a>> IntoCow<'a> for Option<T> {
     }
 }
 
-/// Declares the listed function modules and builds the [`SqlPageFunctionName`] dispatch enum from
-/// them.
+/// Builds the [`SqlPageFunctionName`] dispatch enum from the listed function modules.
 macro_rules! sqlpage_functions {
     ($($func:ident),* $(,)?) => {
-        $(
-            mod $func;
-        )*
 
         /// One variant per built-in `sqlpage.*` function.
         #[derive(Debug, PartialEq, Eq, Clone, Copy)]

--- a/src/webserver/database/sqlpage_functions/functions.rs
+++ b/src/webserver/database/sqlpage_functions/functions.rs
@@ -1,14 +1,52 @@
 //! Built-in `SQLPage` SQL functions.
 //!
 //! Every function is a plain `async fn` in its own module under [`functions/`](self). To add one,
-//! create `functions/<name>.rs` with an `async fn <name>` and add it to the
-//! [`sqlpage_functions!`](super::function_traits::sqlpage_functions) call below. The macro declares
-//! the module and adds it to the dispatch enum. Argument conversion and
-//! dispatch are handled generically in [`super::function_traits`].
+//! create `functions/<name>.rs` with an `async fn <name>`, declare the module below and add it to
+//! the [`sqlpage_functions!`](super::function_traits::sqlpage_functions) call. Argument conversion
+//! and dispatch are handled generically in [`super::function_traits`].
 
 use std::fmt::Write;
 
 use super::function_traits::sqlpage_functions;
+
+mod basic_auth_password;
+mod basic_auth_username;
+mod client_ip;
+mod configuration_directory;
+mod cookie;
+mod current_working_directory;
+mod environment_variable;
+mod exec;
+mod fetch;
+mod fetch_with_meta;
+mod hash_password;
+mod header;
+mod headers;
+mod hmac;
+mod link;
+mod oidc_logout_url;
+mod path;
+mod persist_uploaded_file;
+mod protocol;
+mod random_string;
+mod read_file_as_data_url;
+mod read_file_as_text;
+mod regex_match;
+mod request_body;
+mod request_body_base64;
+mod request_method;
+mod run_sql;
+mod send_mail;
+mod set_variable;
+mod uploaded_file_mime_type;
+mod uploaded_file_name;
+mod uploaded_file_path;
+mod url_encode;
+mod user_info;
+mod user_info_token;
+mod variables;
+mod version;
+mod web_root;
 
 sqlpage_functions! {
     basic_auth_password,
@@ -81,4 +119,34 @@ fn supported_function_list() -> String {
         writeln!(supported, "  - {function}").expect("writing to a String cannot fail");
     }
     supported
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SqlPageFunctionName;
+    use std::collections::BTreeSet;
+
+    #[test]
+    fn functions_directory_matches_registered_functions() {
+        let directory = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/src/webserver/database/sqlpage_functions/functions"
+        );
+        let files: BTreeSet<String> = std::fs::read_dir(directory)
+            .expect("functions directory")
+            .map(|entry| entry.expect("directory entry").path())
+            .filter(|path| path.extension().is_some_and(|extension| extension == "rs"))
+            .map(|path| {
+                path.file_stem()
+                    .expect("file stem")
+                    .to_string_lossy()
+                    .into_owned()
+            })
+            .collect();
+        let registered: BTreeSet<String> = SqlPageFunctionName::ALL
+            .iter()
+            .map(|function| function.name().to_owned())
+            .collect();
+        assert_eq!(files, registered);
+    }
 }

--- a/src/webserver/database/sqlpage_functions/functions/cookie.rs
+++ b/src/webserver/database/sqlpage_functions/functions/cookie.rs
@@ -2,6 +2,9 @@ use std::borrow::Cow;
 
 use crate::webserver::{http_request_info::RequestInfo, single_or_vec::SingleOrVec};
 
-pub(super) async fn cookie<'a>(request: &'a RequestInfo, name: Cow<'a, str>) -> Option<Cow<'a, str>> {
+pub(super) async fn cookie<'a>(
+    request: &'a RequestInfo,
+    name: Cow<'a, str>,
+) -> Option<Cow<'a, str>> {
     request.cookies.get(&*name).map(SingleOrVec::as_json_str)
 }

--- a/src/webserver/database/sqlpage_functions/functions/environment_variable.rs
+++ b/src/webserver/database/sqlpage_functions/functions/environment_variable.rs
@@ -3,7 +3,9 @@ use std::borrow::Cow;
 use anyhow::Context;
 
 /// Returns the value of an environment variable.
-pub(super) async fn environment_variable(name: Cow<'_, str>) -> anyhow::Result<Option<Cow<'_, str>>> {
+pub(super) async fn environment_variable(
+    name: Cow<'_, str>,
+) -> anyhow::Result<Option<Cow<'_, str>>> {
     match std::env::var(&*name) {
         Ok(value) => Ok(Some(Cow::Owned(value))),
         Err(std::env::VarError::NotPresent) if name.contains(['=', '\0']) => anyhow::bail!(

--- a/src/webserver/database/sqlpage_functions/functions/fetch.rs
+++ b/src/webserver/database/sqlpage_functions/functions/fetch.rs
@@ -6,8 +6,7 @@ use tracing::Instrument;
 
 use crate::webserver::{
     database::sqlpage_functions::http_fetch_request::HttpFetchRequest,
-    http_client::make_http_client,
-    http_request_info::RequestInfo,
+    http_client::make_http_client, http_request_info::RequestInfo,
 };
 
 pub(super) fn build_request<'a>(
@@ -94,8 +93,8 @@ pub(super) async fn fetch(
 
     async {
         let response_result = send_request(request, &http_request)?.await;
-        let mut response = response_result
-            .map_err(|e| anyhow!("Unable to fetch {}: {e}", http_request.url))?;
+        let mut response =
+            response_result.map_err(|e| anyhow!("Unable to fetch {}: {e}", http_request.url))?;
 
         tracing::Span::current().record(
             otel::HTTP_RESPONSE_STATUS_CODE,

--- a/src/webserver/database/sqlpage_functions/functions/header.rs
+++ b/src/webserver/database/sqlpage_functions/functions/header.rs
@@ -2,7 +2,10 @@ use std::borrow::Cow;
 
 use crate::webserver::{http_request_info::RequestInfo, single_or_vec::SingleOrVec};
 
-pub(super) async fn header<'a>(request: &'a RequestInfo, name: Cow<'a, str>) -> Option<Cow<'a, str>> {
+pub(super) async fn header<'a>(
+    request: &'a RequestInfo,
+    name: Cow<'a, str>,
+) -> Option<Cow<'a, str>> {
     let lower_name = name.to_ascii_lowercase();
     request
         .headers

--- a/src/webserver/database/sqlpage_functions/functions/persist_uploaded_file.rs
+++ b/src/webserver/database/sqlpage_functions/functions/persist_uploaded_file.rs
@@ -72,7 +72,10 @@ pub(super) async fn persist_uploaded_file<'a>(
 }
 
 #[cfg(unix)]
-pub(super) async fn set_file_mode(path: &std::path::Path, mode: Option<&str>) -> anyhow::Result<()> {
+pub(super) async fn set_file_mode(
+    path: &std::path::Path,
+    mode: Option<&str>,
+) -> anyhow::Result<()> {
     use std::os::unix::fs::PermissionsExt;
     let mode = if let Some(mode) = mode {
         u32::from_str_radix(mode, 8)
@@ -87,6 +90,9 @@ pub(super) async fn set_file_mode(path: &std::path::Path, mode: Option<&str>) ->
 }
 
 #[cfg(not(unix))]
-pub(super) async fn set_file_mode(_path: &std::path::Path, _mode: Option<&str>) -> anyhow::Result<()> {
+pub(super) async fn set_file_mode(
+    _path: &std::path::Path,
+    _mode: Option<&str>,
+) -> anyhow::Result<()> {
     Ok(())
 }

--- a/src/webserver/database/sqlpage_functions/functions/random_string.rs
+++ b/src/webserver/database/sqlpage_functions/functions/random_string.rs
@@ -1,4 +1,3 @@
-
 /// Returns a random string of the specified length.
 pub(super) async fn random_string(len: usize) -> anyhow::Result<String> {
     // OsRng can block on Linux, so we run this on a blocking thread.

--- a/src/webserver/database/sqlpage_functions/functions/read_file_as_data_url.rs
+++ b/src/webserver/database/sqlpage_functions/functions/read_file_as_data_url.rs
@@ -5,14 +5,16 @@ use anyhow::Context;
 use crate::{
     filesystem::FileAccess,
     webserver::{
-        database::blob_to_data_url::vec_to_data_uri_with_mime,
-        http_request_info::RequestInfo,
+        database::blob_to_data_url::vec_to_data_uri_with_mime, http_request_info::RequestInfo,
     },
 };
 
 use super::uploaded_file_mime_type::{mime_from_upload_path, mime_guess_from_filename};
 
-pub(super) async fn read_file_bytes(request: &RequestInfo, path_str: &str) -> Result<Vec<u8>, anyhow::Error> {
+pub(super) async fn read_file_bytes(
+    request: &RequestInfo,
+    path_str: &str,
+) -> Result<Vec<u8>, anyhow::Error> {
     let path = std::path::Path::new(path_str);
     // If the path is relative, it's relative to the web root, not the current working directory,
     // and it can be fetched from the on-database filesystem table

--- a/src/webserver/database/sqlpage_functions/functions/send_mail.rs
+++ b/src/webserver/database/sqlpage_functions/functions/send_mail.rs
@@ -102,10 +102,7 @@ enum SendMailError {
     InvalidEmailCc { address: Option<String> },
     InvalidEmailReplyTo { address: String },
     InvalidAttachmentFilename { index: usize },
-    InvalidAttachment {
-        index: usize,
-        reason: anyhow::Error,
-    },
+    InvalidAttachment { index: usize, reason: anyhow::Error },
     SmtpTlsFailed(anyhow::Error),
     SmtpTimeout(anyhow::Error),
     SmtpRejected(anyhow::Error),
@@ -136,10 +133,11 @@ impl SendMailError {
 impl fmt::Display for SendMailError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::InvalidMessage(reason) => write_reason(formatter, "Invalid email message", reason),
-            Self::SmtpNotConfigured => formatter.write_str(
-                "sqlpage.send_mail() requires the smtp_host configuration option",
-            ),
+            Self::InvalidMessage(reason) => {
+                write_reason(formatter, "Invalid email message", reason)
+            }
+            Self::SmtpNotConfigured => formatter
+                .write_str("sqlpage.send_mail() requires the smtp_host configuration option"),
             Self::MissingEmailFrom => formatter.write_str(
                 "Email has no from address; set its from property or configure smtp_from",
             ),
@@ -153,14 +151,22 @@ impl fmt::Display for SendMailError {
                 write_invalid_recipient(formatter, "cc", address.as_deref())
             }
             Self::InvalidEmailReplyTo { address } => {
-                write!(formatter, "'{address}' is not a valid reply_to email address")
+                write!(
+                    formatter,
+                    "'{address}' is not a valid reply_to email address"
+                )
             }
             Self::InvalidAttachmentFilename { index } => {
-                write!(formatter, "Attachment filename at index {index} must not be empty")
+                write!(
+                    formatter,
+                    "Attachment filename at index {index} must not be empty"
+                )
             }
-            Self::InvalidAttachment { index, reason } => {
-                write_reason(formatter, &format!("Invalid attachment at index {index}"), reason)
-            }
+            Self::InvalidAttachment { index, reason } => write_reason(
+                formatter,
+                &format!("Invalid attachment at index {index}"),
+                reason,
+            ),
             Self::SmtpTlsFailed(reason) => {
                 write_reason(formatter, "Unable to establish SMTP TLS", reason)
             }
@@ -170,9 +176,11 @@ impl fmt::Display for SendMailError {
             Self::SmtpRejected(reason) => {
                 write_reason(formatter, "SMTP server rejected the email", reason)
             }
-            Self::SmtpConnectionFailed(reason) => {
-                write_reason(formatter, "Unable to communicate with the SMTP server", reason)
-            }
+            Self::SmtpConnectionFailed(reason) => write_reason(
+                formatter,
+                "Unable to communicate with the SMTP server",
+                reason,
+            ),
         }
     }
 }
@@ -185,7 +193,10 @@ fn write_invalid_recipient(
     address: Option<&str>,
 ) -> fmt::Result {
     match address {
-        Some(address) => write!(formatter, "'{address}' is not a valid {field} email address"),
+        Some(address) => write!(
+            formatter,
+            "'{address}' is not a valid {field} email address"
+        ),
         None => write!(formatter, "{field} must contain at least one email address"),
     }
 }
@@ -219,10 +230,7 @@ fn send_mail_result_json(result: SendMailResult<()>) -> String {
         Ok(()) => serde_json::json!({ "status": "accepted" }).to_string(),
         Err(error) => {
             let message = format!("{error:#}");
-            log::warn!(
-                "sqlpage.send_mail failed with {}: {message}",
-                error.code()
-            );
+            log::warn!("sqlpage.send_mail failed with {}: {message}", error.code());
             serde_json::json!({
                 "status": "error",
                 "error_code": error.code(),
@@ -300,12 +308,13 @@ fn resolve_bodies(
 
     let html_body = if let Some(markdown_src) = body_md {
         Some(
-            crate::template_helpers::render_markdown_to_html(config, markdown_src)
-                .map_err(|reason| {
+            crate::template_helpers::render_markdown_to_html(config, markdown_src).map_err(
+                |reason| {
                     SendMailError::InvalidMessage(anyhow::anyhow!(
                         "Failed to render body_md as HTML: {reason}"
                     ))
-                })?,
+                },
+            )?,
         )
     } else {
         body_html.map(std::string::ToString::to_string)
@@ -334,7 +343,8 @@ fn build_email(config: &AppConfig, request: MailRequest<'_>) -> SendMailResult<M
         attachments,
     } = request;
 
-    let (text_body, html_body) = resolve_bodies(config, body, body_html.as_ref(), body_md.as_ref())?;
+    let (text_body, html_body) =
+        resolve_bodies(config, body, body_html.as_ref(), body_md.as_ref())?;
 
     let sender = from
         .as_deref()
@@ -345,9 +355,7 @@ fn build_email(config: &AppConfig, request: MailRequest<'_>) -> SendMailResult<M
         .map_err(|_| SendMailError::InvalidEmailFrom {
             address: sender.to_string(),
         })?;
-    let mut email = Message::builder()
-        .from(sender)
-        .subject(subject.as_ref());
+    let mut email = Message::builder().from(sender).subject(subject.as_ref());
     for recipient in to.parse(RecipientField::To)? {
         email = email.to(recipient);
     }
@@ -357,11 +365,12 @@ fn build_email(config: &AppConfig, request: MailRequest<'_>) -> SendMailResult<M
         }
     }
     if let Some(reply_to) = reply_to {
-        let parsed_reply_to = reply_to.parse::<Mailbox>().map_err(|_| {
-            SendMailError::InvalidEmailReplyTo {
-                address: reply_to.to_string(),
-            }
-        })?;
+        let parsed_reply_to =
+            reply_to
+                .parse::<Mailbox>()
+                .map_err(|_| SendMailError::InvalidEmailReplyTo {
+                    address: reply_to.to_string(),
+                })?;
         email = email.reply_to(parsed_reply_to);
     }
     if attachments.is_empty() {
@@ -412,10 +421,9 @@ fn build_email(config: &AppConfig, request: MailRequest<'_>) -> SendMailResult<M
         let content_type = ContentType::parse(media_type)
             .with_context(|| format!("Invalid attachment media type at index {index}"))
             .map_err(|reason| SendMailError::InvalidAttachment { index, reason })?;
-        multipart = multipart.singlepart(Attachment::new(attachment.filename.into_owned()).body(
-            bytes,
-            content_type,
-        ));
+        multipart = multipart.singlepart(
+            Attachment::new(attachment.filename.into_owned()).body(bytes, content_type),
+        );
     }
     email
         .multipart(multipart)
@@ -461,9 +469,7 @@ mod tests {
         thread,
     };
 
-    use super::{
-        SendMailError, SmtpTlsMode, send_mail_result_json, send_mail_with_config,
-    };
+    use super::{SendMailError, SmtpTlsMode, send_mail_result_json, send_mail_with_config};
     use crate::app_config::tests::test_config;
 
     #[tokio::test]
@@ -693,7 +699,11 @@ mod tests {
         .await
         .unwrap_err();
         assert!(matches!(&error, SendMailError::InvalidMessage(_)));
-        assert!(error.to_string().contains("cannot combine 'body_md' with 'body_html'"));
+        assert!(
+            error
+                .to_string()
+                .contains("cannot combine 'body_md' with 'body_html'")
+        );
     }
 
     #[tokio::test]
@@ -711,7 +721,11 @@ mod tests {
         .await
         .unwrap_err();
         assert!(matches!(&error, SendMailError::InvalidMessage(_)));
-        assert!(error.to_string().contains("requires either 'body' or 'body_md'"));
+        assert!(
+            error
+                .to_string()
+                .contains("requires either 'body' or 'body_md'")
+        );
     }
 
     #[tokio::test]
@@ -773,10 +787,7 @@ mod tests {
         )
         .await
         .unwrap_err();
-        assert!(matches!(
-            &error,
-            SendMailError::InvalidAttachment { .. }
-        ));
+        assert!(matches!(&error, SendMailError::InvalidAttachment { .. }));
         assert!(format!("{error:#}").contains("Decoded data exceeds the limit of 1 bytes"));
     }
 

--- a/src/webserver/database/sqlpage_functions/functions/set_variable.rs
+++ b/src/webserver/database/sqlpage_functions/functions/set_variable.rs
@@ -2,8 +2,7 @@ use std::borrow::Cow;
 
 use crate::webserver::{
     database::sqlpage_functions::url_parameters::URLParameters,
-    http_request_info::ExecutionContext,
-    single_or_vec::SingleOrVec,
+    http_request_info::ExecutionContext, single_or_vec::SingleOrVec,
 };
 
 pub(super) async fn set_variable<'a>(

--- a/src/webserver/database/sqlpage_functions/functions/uploaded_file_mime_type.rs
+++ b/src/webserver/database/sqlpage_functions/functions/uploaded_file_mime_type.rs
@@ -4,7 +4,10 @@ use mime_guess::mime;
 
 use crate::webserver::http_request_info::RequestInfo;
 
-pub(super) fn mime_from_upload_path<'a>(request: &'a RequestInfo, path: &str) -> Option<&'a mime_guess::Mime> {
+pub(super) fn mime_from_upload_path<'a>(
+    request: &'a RequestInfo,
+    path: &str,
+) -> Option<&'a mime_guess::Mime> {
     request.uploaded_files.values().find_map(|uploaded_file| {
         if uploaded_file.file.path() == OsStr::new(path) {
             uploaded_file.content_type.as_ref()

--- a/src/webserver/database/sqlpage_functions/functions/version.rs
+++ b/src/webserver/database/sqlpage_functions/functions/version.rs
@@ -1,4 +1,3 @@
-
 /// Returns the version of the sqlpage that is running.
 pub(super) async fn version() -> &'static str {
     env!("CARGO_PKG_VERSION")


### PR DESCRIPTION
### Motivation

- `cargo fmt` silently skipped all 38 files under `sqlpage_functions/functions/`. 
- Eleven of those files had drifted from the default style.

### Description

Two commits in this PR. 

- `959f73ad` 
  - moves the module declarations out of the macro into plain `mod` items next to it. A function missing `mod` is a resolution error. An orphaned `mod` is a dead-code warning. 
  - rust-analyzer can now resolve these modules too. 
  - Adds a `.git-blame-ignore-revs` scaffold. We need to wait to merge into mainline to be able to pull the commit hash off mainline to ignore. 
- `a732ccac` runs `cargo fmt --all`. committed in a separate commit so that it can be added to `.git-blame-ignore-revs`.

### Testing

n/a :: no behaviour changes