### PR TITLE
'fix(fetch_with_meta) :: return json bodies under the documented key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
  - Screen readers now announce the title of the modal component instead of an unnamed dialog.
  - `sqlpage.request_body` and `sqlpage.request_body_base64` now return NULL when the request has no body. A body that cannot be read, such as one exceeding the payload limit, is now reported as an error instead of being silently replaced with an empty body.
  - List-valued configuration options, including OIDC paths and trusted audiences, can now be set through environment variables as space-separated lists.
+ - `sqlpage.fetch_with_meta` now correctly documents server JSON responses sent under `json_body`, not `body`.
  - Datagrid rows with an icon or image no longer display an unnecessary en-dash placeholder, and an explicitly empty description remains empty.
  - Charts can display reference lines. A row with a `yline` is drawn as a line across the chart at that value of the y axis, with the row's `label` and `color` for its text and its color. Reference lines are rows, so a chart can have as many of them as the query returns. A line follows its axis, so on a `horizontal` bar chart a `yline` is drawn down the chart rather than across it. They are not added to the total of a `stacked` chart, and are not filled in an `area` chart.
 

--- a/examples/official-site/sqlpage/migrations/58_fetch_with_meta.sql
+++ b/examples/official-site/sqlpage/migrations/58_fetch_with_meta.sql
@@ -11,7 +11,19 @@ VALUES (
         'Sends an HTTP request and returns detailed metadata about the response, including status code, headers, and body.
 
 This function is similar to [`fetch`](?function=fetch), but returns a JSON object containing detailed information about the response.
-The returned object has the following structure:
+When the response declares a `content-type` of `application/json`, the parsed body is returned under `json_body`:
+```json
+{
+    "status": 200,
+    "headers": {
+        "content-type": "application/json",
+        "content-length": "1234"
+    },
+    "json_body": { "name": "ditto" }
+}
+```
+
+For every other content type, the body is returned as a string under `body`:
 ```json
 {
     "status": 200,
@@ -19,8 +31,7 @@ The returned object has the following structure:
         "content-type": "text/html",
         "content-length": "1234"
     },
-    "body": "a string, or a json object, depending on the content type",
-    "error": "error message if any"
+    "body": "<html>...</html>"
 }
 ```
 
@@ -42,8 +53,8 @@ where
 -- Extract data from the response json body
 select ''card'' as component;
 select
-    json_extract($response, ''$.body.name'') as title,
-    json_extract($response, ''$.body.abilities[0].ability.name'') as description
+    json_extract($response, ''$.json_body.name'') as title,
+    json_extract($response, ''$.json_body.abilities[0].ability.name'') as description
 from $response;
 ```
 

--- a/examples/official-site/your-first-sql-website/index.sql
+++ b/examples/official-site/your-first-sql-website/index.sql
@@ -23,7 +23,7 @@ SET req = '{
     "timeout_ms": 200
 }';
 SET api_results = sqlpage.fetch_with_meta($req);
-SET sqlpage_version = COALESCE(json_extract($api_results, '$.body.tag_name'), '');
+SET sqlpage_version = COALESCE(json_extract($api_results, '$.json_body.tag_name'), '');
 
 SELECT 'hero' as component,
     'Your first SQL Website' as title,

--- a/src/webserver/database/sqlpage_functions/functions/user_info.rs
+++ b/src/webserver/database/sqlpage_functions/functions/user_info.rs
@@ -64,7 +64,7 @@ pub(super) async fn user_info<'a>(
         "gender" => claims.gender().map(|g| g.to_string()), // Assumes GenderClaim impls ToString
         "birthdate" => claims.birthdate().map(|b| b.to_string()), // Assumes Birthdate impls ToString
         "zoneinfo" => claims.zoneinfo().map(|z| z.to_string()),   // Assumes ZoneInfo impls ToString
-        "locale" => claims.locale().map(ToString::to_string), // Assumes Locale impls ToString
+        "locale" => claims.locale().map(ToString::to_string),     // Assumes Locale impls ToString
         "updated_at" => claims.updated_at().map(|t| t.timestamp().to_string()),
 
         // Standard Claims (Email Scope)

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -150,12 +150,21 @@ pub(crate) fn start_echo_server(shutdown: oneshot::Receiver<()>) -> (JoinHandle<
     let listener = std::net::TcpListener::bind("localhost:0").unwrap();
     let port = listener.local_addr().unwrap().port();
     let server = HttpServer::new(|| {
-        App::new().default_service(fn_service(|mut req: ServiceRequest| async move {
-            let meta = format_request_line_and_headers(&req);
-            let body = format_body(&mut req).await;
-            let resp = build_echo_response(&body, meta);
-            Ok(req.into_response(resp))
-        }))
+        App::new()
+            .route(
+                "/json",
+                web::to(|body: web::Bytes| async move {
+                    HttpResponse::Ok()
+                        .insert_header((header::CONTENT_TYPE, "application/json"))
+                        .body(body)
+                }),
+            )
+            .default_service(fn_service(|mut req: ServiceRequest| async move {
+                let meta = format_request_line_and_headers(&req);
+                let body = format_body(&mut req).await;
+                let resp = build_echo_response(&body, meta);
+                Ok(req.into_response(resp))
+            }))
     })
     .workers(1)
     .listen(listener)

--- a/tests/sql_test_files/data/fetch_with_meta_json_body.sql
+++ b/tests/sql_test_files/data/fetch_with_meta_json_body.sql
@@ -1,0 +1,5 @@
+set url = 'http://localhost:' || $echo_port || '/json';
+set fetch_req = '{"method":"POST","url":"' || $url || '","body":{"hello":"world"}}';
+set res = sqlpage.fetch_with_meta($fetch_req);
+
+select '"json_body":{"hello":"world"}' as expected_contains, $res as actual;


### PR DESCRIPTION
addresses B3 in #1386 
> **What happens.** `sqlpage.fetch_with_meta` returns the response body under the key `body` for text responses and under `json_body` for JSON responses. The documentation
(`examples/official-site/sqlpage/migrations/58_fetch_with_meta.sql:14-23`) documents a single `body` key holding "a string, or a json object, depending on the content type".

lmk if you would rather I go the other direction where we document `json_body`. to me it seemed better to overload the known `body` key