### PR TITLE
feat(rust) :: add mutants.rs as nonblocking step to CI

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,0 +1,10 @@
+# Configuration for cargo-mutants <https://mutants.rs>.
+# Run locally with `cargo mutants`; CI runs it against the pull request diff.
+
+# ignore build.rs downloads and hashes frontend assets at build time as well as
+# executing the build.
+exclude_globs = ["build.rs"]
+
+# The suite starts a web server and talks to a database, so a mutant that
+# deadlocks needs a longer leash than the ~4s baseline would allow.
+minimum_test_timeout = 60

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -543,3 +543,30 @@ jobs:
           TAG_SUFFIX: ${{ matrix.variant != 'minimal' && format('-{0}', matrix.variant) || '' }}
         run: |
           docker buildx imagetools inspect "${REGISTRY_IMAGE}:${GITHUB_REF_NAME}${TAG_SUFFIX}"
+
+  mutants:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-mutants
+      - name: Set up cargo cache
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
+        with:
+          shared-key: rust-sqlpage-mutants
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: Mutate only the lines this pull request changed
+        run: |
+          git diff "origin/${{ github.base_ref }}...HEAD" > mutants.diff
+          cargo mutants --in-diff mutants.diff --jobs 2
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: mutants-report
+          path: mutants.out/

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ sqlpage/sqlpage.db
 tests_uploads/
 /test-results/
 /playwright-report/
+/mutants.out*/
+mutants.diff

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
  - `stacked` is now ignored on chart types that cannot stack, instead of displaying an empty chart.
  - Screen readers now announce the title of the modal component instead of an unnamed dialog.
  - `sqlpage.request_body` and `sqlpage.request_body_base64` now return NULL when the request has no body. A body that cannot be read, such as one exceeding the payload limit, is now reported as an error instead of being silently replaced with an empty body.
+ - `sqlpage.fetch_with_meta` now returns JSON response bodies under the documented `body` key.
 
 ## v0.45
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,6 +95,19 @@ export DATABASE_URL=mssql://root:Password123!@localhost/sqlpage
 cargo test
 ```
 
+### Mutation Testing
+
+[cargo-mutants](https://mutants.rs) finds dead code or missing tests by mutating 
+params and re-running the suite.
+
+```bash
+cargo mutants --in-diff <(git diff origin/main...HEAD) # what your branch changed
+```
+
+A whole-codebase run takes hours, so CI only mutates the lines a pull request
+touches, and reports without failing the build. Results are attached to the run
+as the `mutants-report` artifact.
+
 ### End-to-End Tests
 
 We use Playwright for end-to-end testing of dynamic frontend features.
@@ -225,6 +238,7 @@ git checkout -b feature/your-feature-name
    - Execute all tests across multiple platforms (Linux, Windows)
    - Build Docker images for multiple architectures
    - Run frontend linting, typechecking and unit tests (`npm test`)
+   - Report surviving mutants for the lines the pull request changed
    - Test against multiple databases (SQLite, PostgreSQL, MySQL, MSSQL, Oracle, and ODBC)
 
 ## Release Process


### PR DESCRIPTION
adds mutation testing for Rust as a non-blocking step to the CI :: https://mutants.rs/

This step is non-blocking as it does find issues, but it is up to the reader to interpret the results (at least for me I don't know of a quick way to do it just yet). It also is kinda really slow. I ran it over the entire codebase on my Ryzen 7 5800X3D ~3h (09:56 → 13:07). I left it running through the day as I was at work and these are the results.

```lock.json
{
  "cargo_mutants_version": "27.1.0",
  "start_time": "2026-08-21T13:56:34.66744901Z",
  "hostname": "jager",
  "username": "reap"
}
```
 see #1396 for a more detailed breakdown of the full run

the goal is to break down these things into groups and create an issue to dicuss more about how this can help improve the codebase. this also is an progammatic way to catch the remaining issues called out in #1389 