### PR TITLE
fix(ci): avoid rebuilding email example image

### DIFF
--- a/examples/sending emails/README.md
+++ b/examples/sending emails/README.md
@@ -5,7 +5,7 @@ This example sends plain-text email with [`sqlpage.send_mail`](https://sql-page.
 Run the example:
 
 ```sh
-docker compose up --build
+docker compose -f docker-compose.yml -f docker-compose.local.yml up --build
 ```
 
 This builds SQLPage from the current repository checkout before starting the example.

--- a/examples/sending emails/docker-compose.local.yml
+++ b/examples/sending emails/docker-compose.local.yml
@@ -1,0 +1,6 @@
+services:
+  web:
+    build:
+      context: ../..
+      args:
+        CARGO_PROFILE: dev

--- a/examples/sending emails/docker-compose.yml
+++ b/examples/sending emails/docker-compose.yml
@@ -1,10 +1,6 @@
 services:
   web:
     image: lovasoa/sqlpage:main
-    build:
-      context: ../..
-      args:
-        CARGO_PROFILE: dev
     ports:
       - "8080:8080"
     environment:


### PR DESCRIPTION
## Summary
- keep the email example's CI Compose file image-only
- preserve local checkout builds through docker-compose.local.yml
- update the README command accordingly

## Why
The Hurl runner always passes --build. The email example previously pointed its build context at the repository root and used the dev Cargo profile, so CI rebuilt all SQLPage dependencies in the Hurl job even after downloading the prebuilt image. In run 32626998346, this added roughly 3m40s while the Hurl requests took about 1.2s.

## Validation
- docker compose -f examples/sending emails/docker-compose.yml config
- docker compose -f examples/sending emails/docker-compose.yml -f examples/sending emails/docker-compose.local.yml config
- git diff --check

The full Hurl test was not run locally because lovasoa/sqlpage:main was not available locally.