### PR TITLE
fix(ci): quiet Rust test output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,7 @@ jobs:
           fi
           for test_binary in "${test_binaries[@]}"; do
             echo "::group::$(basename "$test_binary")"
-            "$test_binary"
+            "$test_binary" --quiet
             echo "::endgroup::"
           done
         env:

--- a/src/webserver/database/error_highlighting.rs
+++ b/src/webserver/database/error_highlighting.rs
@@ -95,6 +95,10 @@ impl std::error::Error for NicePositionedError {
     }
 }
 
+pub(super) fn is_positioned_error(error: &anyhow::Error) -> bool {
+    error.downcast_ref::<NicePositionedError>().is_some()
+}
+
 /// Display a database error without any position information
 #[must_use]
 pub(super) fn display_db_error(

--- a/src/webserver/database/execute_queries.rs
+++ b/src/webserver/database/execute_queries.rs
@@ -321,11 +321,10 @@ pub fn stop_at_first_error(
 
     results_stream
         .inspect(move |item| {
-            if let DbItem::Error(err) = item {
-                log::error!("{err:?}");
-                if let Some(tx) = error_tx.take() {
-                    let _ = tx.send(());
-                }
+            if matches!(item, DbItem::Error(_))
+                && let Some(tx) = error_tx.take()
+            {
+                let _ = tx.send(());
             }
         })
         .take_until(error_rx)

--- a/src/webserver/database/execute_queries.rs
+++ b/src/webserver/database/execute_queries.rs
@@ -8,7 +8,7 @@ use std::pin::Pin;
 use tracing::Instrument;
 
 use super::csv_import::run_csv_import;
-use super::error_highlighting::{display_stmt_db_error, display_stmt_error};
+use super::error_highlighting::{display_stmt_db_error, display_stmt_error, is_positioned_error};
 use super::sql::{
     DatabaseQuery, FileStatement, OutputColumn, Query, QueryBody, SingleRowQuery, SourceSpan,
     SqlFile,
@@ -301,7 +301,7 @@ fn with_stmt_position(
     query_position: SourceSpan,
     error: anyhow::Error,
 ) -> anyhow::Error {
-    if error.downcast_ref::<ErrorWithStatus>().is_some() {
+    if error.downcast_ref::<ErrorWithStatus>().is_some() || is_positioned_error(&error) {
         error
     } else {
         display_stmt_error(source_file, query_position, error)

--- a/src/webserver/database/sqlpage_functions/functions/run_sql.rs
+++ b/src/webserver/database/sqlpage_functions/functions/run_sql.rs
@@ -75,7 +75,7 @@ pub(super) async fn run_sql<'a>(
             }
             FinishedQuery => log::trace!("run_sql: Finished query"),
             Error(err) => {
-                return Err(err.context(format!("run_sql: unable to run {sql_file_path:?}")));
+                return Err(err);
             }
         }
     }

--- a/tests/sql_test_files/mod.rs
+++ b/tests/sql_test_files/mod.rs
@@ -257,6 +257,13 @@ fn assert_html_test(body: &str, test_file: &std::path::Path, stem: &str) {
             expected,
             test_file.display()
         );
+        if stem == "error_too_many_nested_inclusions" {
+            assert!(
+                !body.contains("run_sql: unable to run"),
+                "Recursive inclusion error should not repeat run_sql context: {}",
+                test_file.display()
+            );
+        }
     } else {
         if let Some(error) = extract_error(body) {
             panic!("Error in {}: {}", test_file.display(), error);


### PR DESCRIPTION
## Problem

The PostgreSQL matrix failure in [the referenced job](https://github.com/sqlpage/SQLPage/actions/runs/33302391554/job/99233053779?pr=1363) is difficult to diagnose because the failure output contains every passing test and a very large repeated SQL error.

## Root Cause

`stop_at_first_error` logged every `DbItem::Error` with the full `anyhow` chain at `error` level. The same error was then handled downstream. For `error_too_many_nested_inclusions.sql`, each recursive `sqlpage.run_sql` context was included repeatedly, producing a huge `target=sqlpage::webserver::database::execute_queries` line. The aggregate SQL-file test attached all captured logs to one failure.

Recursive errors were also wrapped again by each parent `run_sql` call and statement-position formatter, so development error pages repeated the same context.

## Fix

- Stop logging the database error redundantly in `stop_at_first_error`; downstream error handling remains responsible for the error response.
- Run compiled Rust test binaries with `--quiet` in the database matrix, removing successful-test chatter while preserving failures and captured diagnostics.
- Preserve an already-positioned nested error instead of wrapping it again, and return nested `run_sql` errors without adding repeated context.
- Assert that the recursive-inclusion fixture does not expose repeated `run_sql: unable to run` context.

### Before

From the linked job:

```text
running 75 tests
test basic::test_static_files ... ok
test configuration_docs::configuration_md_documents_every_option ... ok
... dozens of other passing tests ...
test sql_test_files::run_all_sql_test_files ... FAILED

---- sql_test_files::run_all_sql_test_files stdout ----
ts=... level=error msg="In \\"tests/sql_test_files/component_rendering/error_too_many_nested_inclusions.sql\\": ... run_sql: unable to run ... run_sql: unable to run ... [repeated recursive context]" target=sqlpage::webserver::database::execute_queries
...
Test timeout: tests/sql_test_files/data/fetch_with_meta_error.sql
```

### After

The same failure retains the actionable test and panic while removing passing-test chatter and the duplicate recursive log:

```text
running 75 tests
sql_test_files::run_all_sql_test_files --- FAILED

---- sql_test_files::run_all_sql_test_files stdout ----
...
Test timeout: tests/sql_test_files/data/fetch_with_meta_error.sql
```

For a recursive inclusion request in development, the response now contains one positioned error with the `Too many nested inclusions` message, rather than a repeated `run_sql: unable to run` chain. Production behavior remains the generic safe error response.

## Validation

- `cargo test --quiet`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check`