### PR TITLE
Fix zero-valued chart reference lines

### DIFF
--- a/sqlpage/templates/chart.handlebars
+++ b/sqlpage/templates/chart.handlebars
@@ -40,7 +40,7 @@
     "points": [
     {{~#each_row~}}
         {{~#if (gt @row_index 0)}},{{/if~}}
-        {{~#if (or xline yline)~}}
+        {{~#if (default xline (default yline false)) includeZero=true~}}
         {
             "xline": {{~stringify xline}}, "xline_end": {{~stringify xline_end}},
             "yline": {{~stringify yline}}, "yline_end": {{~stringify yline_end}},


### PR DESCRIPTION
A chart row with `xline = 0` or `yline = 0` was serialized as a data point because the Handlebars truthiness check treated zero as false. Include explicit zero checks so zero-valued annotations render as reference lines.