### PR TITLE
fix(ci) :: improve CI to be less flakey

### DIFF
--- a/db-test-setup/mssql/Dockerfile
+++ b/db-test-setup/mssql/Dockerfile
@@ -19,6 +19,6 @@ ENV SA_PASSWORD="Password123!"
 ENV ACCEPT_EULA="Y"
 
 HEALTHCHECK --interval=10s --timeout=3s --start-period=15s --retries=10 \
-    CMD sqlcmd -S localhost -U root -P "Password123!" -Q "SELECT 1" || exit 1
+    CMD /opt/mssql-tools18/bin/sqlcmd -S localhost -U root -P "Password123!" -Q "SELECT 1" -No || exit 1
 
 ENTRYPOINT ["/usr/config/entrypoint.sh"]

--- a/db-test-setup/mssql/entrypoint.sh
+++ b/db-test-setup/mssql/entrypoint.sh
@@ -1,13 +1,18 @@
 #!/usr/bin/env bash
+set -eu
 
 /opt/mssql/bin/sqlservr &
 pid=$!
 
-# Wait 15 seconds for SQL Server to start up
-sleep 15
+# Creating the login below fails silently and permanently if it runs before the
+# server accepts connections, so wait for it rather than sleeping a fixed delay.
+for _ in $(seq 60); do
+    if /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "$SA_PASSWORD" -Q "SELECT 1" -b -o /dev/null -No; then
+        break
+    fi
+    sleep 1
+done
 
-# Run the setup script to create the DB and the schema in the DB
-/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "$SA_PASSWORD" -d master -i setup.sql -No
+/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "$SA_PASSWORD" -d master -i setup.sql -b -No
 
-# Wait for sqlservr to exit
 wait -n $pid

--- a/db-test-setup/mssql/setup.sql
+++ b/db-test-setup/mssql/setup.sql
@@ -7,8 +7,16 @@ GO
 USE sqlpage;
 GO
 
-CREATE LOGIN root WITH PASSWORD = 'Password123!';
-CREATE USER root FOR LOGIN root;
+IF SUSER_ID('root') IS NULL
+    BEGIN
+        CREATE LOGIN root WITH PASSWORD = 'Password123!';
+    END;
+GO
+
+IF USER_ID('root') IS NULL
+    BEGIN
+        CREATE USER root FOR LOGIN root;
+    END;
 GO
 
 GRANT CREATE TABLE TO root;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,10 @@ services:
       POSTGRES_PASSWORD: Password123!
     healthcheck:
       test: pg_isready -U root -d sqlpage
+      interval: 3s
+      timeout: 5s
+      retries: 25
+      start_period: 10s
 
   mysql:
     profiles: ["mysql"]
@@ -43,6 +47,12 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: Password123!
       MYSQL_DATABASE: sqlpage
+    healthcheck:
+      test: mysql -h 127.0.0.1 -u root -p"Password123!" -e "select 1" sqlpage
+      interval: 3s
+      timeout: 5s
+      retries: 25
+      start_period: 10s
 
   mssql:
     profiles: ["mssql"]
@@ -50,9 +60,9 @@ services:
     build: { context: "db-test-setup/mssql" }
     healthcheck:
       test: /opt/mssql-tools18/bin/sqlcmd -S localhost -U root -P "Password123!" -Q "SELECT 1" -b -o /dev/null -No
-      interval: 10s
-      timeout: 3s
-      retries: 10
+      interval: 3s
+      timeout: 5s
+      retries: 25
       start_period: 10s
 
   mariadb:
@@ -62,6 +72,12 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: Password123!
       MYSQL_DATABASE: sqlpage
+    healthcheck:
+      test: healthcheck.sh --connect --innodb_initialized
+      interval: 3s
+      timeout: 5s
+      retries: 25
+      start_period: 10s
 
   oracle:
     profiles: ["oracle"]
@@ -73,7 +89,7 @@ services:
       APP_USER_PASSWORD: Password123!
     healthcheck:
       test: ["CMD", "healthcheck.sh"]
-      interval: 10s
+      interval: 3s
       timeout: 5s
-      retries: 10
-      start_period: 5s
+      retries: 25
+      start_period: 10s


### PR DESCRIPTION
1. [fix(ci) :: wait for mysql and mariadb to accept connections before running the tests](https://github.com/sqlpage/SQLPage/commit/518b681864bb4058c2e1180afcf9c8f12aa9dfe0)
2. [fix(ci) :: replace sleep 15 with poll for mysql](https://github.com/sqlpage/SQLPage/commit/30b1d113b1f98d2a8d7d51e0a551de97fab7529d)
3. [fix(ci) :: make setup idempotent](https://github.com/sqlpage/SQLPage/commit/bb18419185e1a865c81341f803e3f5db372d1179)