### PR TITLE
fix(cookie) :: test the security attributes on a cookie

### DIFF
--- a/tests/cookies/mod.rs
+++ b/tests/cookies/mod.rs
@@ -1,0 +1,31 @@
+use crate::common::req_path;
+use actix_web::http::header::SET_COOKIE;
+
+async fn set_cookie_header(path: &str) -> String {
+    let resp = req_path(path).await.unwrap();
+    resp.headers()
+        .get(SET_COOKIE)
+        .unwrap_or_else(|| panic!("{path} should have sent a Set-Cookie header"))
+        .to_str()
+        .unwrap()
+        .to_owned()
+}
+
+#[actix_web::test]
+async fn cookies_are_http_only_secure_and_same_site_strict_by_default() {
+    let header = set_cookie_header("/tests/cookies/set_cookie_defaults.sql").await;
+    assert!(header.starts_with("session=abc123"), "{header}");
+    assert!(header.contains("HttpOnly"), "{header}");
+    assert!(header.contains("Secure"), "{header}");
+    assert!(header.contains("SameSite=Strict"), "{header}");
+    assert!(header.contains("Path=/"), "{header}");
+}
+
+#[actix_web::test]
+async fn zero_turns_off_a_cookie_protection() {
+    let header = set_cookie_header("/tests/cookies/set_cookie_opt_out.sql").await;
+    assert!(!header.contains("HttpOnly"), "{header}");
+    assert!(!header.contains("Secure"), "{header}");
+    assert!(header.contains("SameSite=Lax"), "{header}");
+    assert!(header.contains("Path=/admin"), "{header}");
+}

--- a/tests/cookies/set_cookie_defaults.sql
+++ b/tests/cookies/set_cookie_defaults.sql
@@ -1,0 +1,2 @@
+select 'cookie' as component, 'session' as name, 'abc123' as value;
+select 'text' as component, 'ok' as contents;

--- a/tests/cookies/set_cookie_opt_out.sql
+++ b/tests/cookies/set_cookie_opt_out.sql
@@ -1,0 +1,8 @@
+select 'cookie' as component,
+    'session' as name,
+    'abc123' as value,
+    0 as http_only,
+    0 as secure,
+    'lax' as same_site,
+    '/admin' as path;
+select 'text' as component, 'ok' as contents;

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,6 +1,7 @@
 mod basic;
 mod common;
 mod configuration_docs;
+mod cookies;
 mod core;
 mod data_formats;
 mod errors;


### PR DESCRIPTION
Nothing checked that a cookie is `HttpOnly`, `Secure`, `SameSite=Strict` and scoped to `/` by default. Nothing checked that MySQL, MSSQL, and Oracle (which have no `boolean` literal) was able to set cookie overrides with `0`.

Adds tests for these cases.

found by #1396 