### PR TITLE
tests(cookie) :: test cookie removal and expiry

### DIFF
--- a/tests/cookies/cookie_expires_rfc3339.sql
+++ b/tests/cookies/cookie_expires_rfc3339.sql
@@ -1,0 +1,5 @@
+select 'cookie' as component,
+    'session' as name,
+    'abc123' as value,
+    '2035-06-15T12:34:56Z' as expires;
+select 'text' as component, 'ok' as contents;

--- a/tests/cookies/cookie_expires_timestamp.sql
+++ b/tests/cookies/cookie_expires_timestamp.sql
@@ -1,0 +1,5 @@
+select 'cookie' as component,
+    'session' as name,
+    'abc123' as value,
+    1988150400 as expires;
+select 'text' as component, 'ok' as contents;

--- a/tests/cookies/mod.rs
+++ b/tests/cookies/mod.rs
@@ -29,3 +29,28 @@ async fn zero_turns_off_a_cookie_protection() {
     assert!(header.contains("SameSite=Lax"), "{header}");
     assert!(header.contains("Path=/admin"), "{header}");
 }
+
+#[actix_web::test]
+async fn removing_a_cookie_expires_it() {
+    let header = set_cookie_header("/tests/cookies/remove_cookie.sql").await;
+    assert!(header.starts_with("session=;"), "{header}");
+    assert!(header.contains("Max-Age=0"), "{header}");
+}
+
+#[actix_web::test]
+async fn an_rfc_3339_expires_date_becomes_an_http_date() {
+    let header = set_cookie_header("/tests/cookies/cookie_expires_rfc3339.sql").await;
+    assert!(
+        header.contains("Expires=Fri, 15 Jun 2035 12:34:56 GMT"),
+        "{header}"
+    );
+}
+
+#[actix_web::test]
+async fn a_unix_timestamp_expires_date_becomes_an_http_date() {
+    let header = set_cookie_header("/tests/cookies/cookie_expires_timestamp.sql").await;
+    assert!(
+        header.contains("Expires=Sat, 01 Jan 2033 00:00:00 GMT"),
+        "{header}"
+    );
+}

--- a/tests/cookies/remove_cookie.sql
+++ b/tests/cookies/remove_cookie.sql
@@ -1,0 +1,2 @@
+select 'cookie' as component, 'session' as name, 1 as remove;
+select 'text' as component, 'ok' as contents;


### PR DESCRIPTION
The cookie component can end a cookie three ways :: (1) remove sends an empty value with `Max-Age=0`, (2) expires accepts a RFC 3339 string, or (3)expires accepts an Unix timestamp. Adds tests for all three cases.

discovered by #1396 