### PR TITLE
test(log) :: test the log component in both render phases

### DIFF
--- a/tests/cookies/log_before_cookie.sql
+++ b/tests/cookies/log_before_cookie.sql
@@ -1,0 +1,3 @@
+select 'log' as component, 'logging before setting a cookie' as message;
+select 'cookie' as component, 'session' as name, 'abc123' as value;
+select 'text' as component, 'ok' as contents;

--- a/tests/cookies/mod.rs
+++ b/tests/cookies/mod.rs
@@ -29,3 +29,9 @@ async fn zero_turns_off_a_cookie_protection() {
     assert!(header.contains("SameSite=Lax"), "{header}");
     assert!(header.contains("Path=/admin"), "{header}");
 }
+
+#[actix_web::test]
+async fn a_log_row_does_not_end_the_header_phase() {
+    let header = set_cookie_header("/tests/cookies/log_before_cookie.sql").await;
+    assert!(header.starts_with("session=abc123"), "{header}");
+}

--- a/tests/sql_test_files/component_rendering/log_after_body.sql
+++ b/tests/sql_test_files/component_rendering/log_after_body.sql
@@ -1,0 +1,3 @@
+select 'text' as component, 'It works !' as contents;
+select 'log' as component, 'logging after the body has started' as message;
+select 'text' as component, 'It works !' as contents;


### PR DESCRIPTION
SQLPage handles a log row two ways :: 

(1) before the body opens, the header phase stays open, so a cookie can still follow a log, and 

(2) after the body opens, the row goes to the server log instead of onto the page. Adds tests for these cases.

discovered by #1396 