### PR TITLE
test(app_config) :: test the documented connection timeout defaults

### DIFF
--- a/src/app_config.rs
+++ b/src/app_config.rs
@@ -863,6 +863,56 @@ mod test {
         assert!(error.contains("SMTP credentials require smtp_tls_mode"));
     }
 
+    fn config_with_timeouts(json: &str) -> AppConfig {
+        let mut config = serde_json::from_str::<AppConfig>(json).unwrap();
+        config.resolve_timeouts();
+        config
+    }
+
+    #[test]
+    fn a_zero_connection_timeout_disables_it() {
+        let config = config_with_timeouts(
+            r#"{
+                "database_url": "postgres://localhost/test",
+                "database_connection_idle_timeout_seconds": 0,
+                "database_connection_max_lifetime_seconds": 120
+            }"#,
+        );
+        assert_eq!(config.database_connection_idle_timeout, None);
+        assert_eq!(
+            config.database_connection_max_lifetime,
+            Some(Duration::from_mins(2))
+        );
+    }
+
+    #[test]
+    fn connection_timeouts_fall_back_to_the_documented_defaults() {
+        let config = config_with_timeouts(r#"{"database_url": "postgres://localhost/test"}"#);
+        assert_eq!(
+            config.database_connection_idle_timeout,
+            Some(Duration::from_mins(30))
+        );
+        assert_eq!(
+            config.database_connection_max_lifetime,
+            Some(Duration::from_hours(1))
+        );
+
+        let sqlite = config_with_timeouts(r#"{"database_url": "sqlite://:memory:"}"#);
+        assert_eq!(sqlite.database_connection_idle_timeout, None);
+        assert_eq!(sqlite.database_connection_max_lifetime, None);
+    }
+
+    #[test]
+    fn an_empty_database_pool_is_rejected() {
+        let mut config = tests::test_config();
+        config.max_database_pool_connections = Some(0);
+        let error = config.validate().unwrap_err().to_string();
+        assert!(error.contains("greater than 0"), "{error}");
+
+        config.max_database_pool_connections = Some(1);
+        config.validate().unwrap();
+    }
+
     #[test]
     fn smtp_credentials_must_be_configured_together() {
         let mut config = tests::test_config();


### PR DESCRIPTION
`configuration.md` documents that (1) the idle timeout defaults to 30 minutes, (2) the maximum lifetime to an hour, (3) that SQLite doesn't have those limits, and (4) that `0` disables the timeout. Adds tests for these cases.

discovered by #1396 

https://github.com/sqlpage/SQLPage/blob/6d32b4052e55e4824961f0b48fef2ca42b142298/configuration.md?plain=1#L18-L19

