### PR TITLE
feat(chart): add links to data point tooltips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ## v0.46.1
 
+- Chart data points can now include a `link`, which is shown as a clickable link in the point's tooltip.
 - Upgraded the bundled ApexCharts from v5.13.0 to [v7.1.0](https://github.com/apexcharts/apexcharts.js/releases/tag/v7.1.0) and the Tabler core from v1.4.0 to v1.5.0. The ApexCharts upgrade fixes logarithmic-axis scaling, stacked baselines on irregular data, and annotations on charts with no data, and ships a smaller default bundle.
 - Fixed modal dialog boxes appearing behind their backdrop, which made them impossible to close by clicking their close button. Tabler 1.5 sets `contain: layout` on the page container, which broke the fixed positioning of modals rendered inside it; modals are now moved to the top level of the page, as recommended by Bootstrap.
 - Fixed a regression introduced in v0.46 that could replace a variable with `NULL` while building a value that also used database expressions and `sqlpage.*` functions. For example, this API request could lose `john.doe` and produce a URL ending at `https://api.example.com/`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## unreleased
 
+- Chart data points can now include a `link`, which is shown as a clickable link in the point's tooltip.
 - Numeric x values on Cartesian charts now explicitly use a continuous numeric axis, preventing fractional tick positions from being displayed as misleading rounded integers.
 
 ## v0.46.1
 
-- Chart data points can now include a `link`, which is shown as a clickable link in the point's tooltip.
 - Upgraded the bundled ApexCharts from v5.13.0 to [v7.1.0](https://github.com/apexcharts/apexcharts.js/releases/tag/v7.1.0) and the Tabler core from v1.4.0 to v1.5.0. The ApexCharts upgrade fixes logarithmic-axis scaling, stacked baselines on irregular data, and annotations on charts with no data, and ships a smaller default bundle.
 - Fixed modal dialog boxes appearing behind their backdrop, which made them impossible to close by clicking their close button. Tabler 1.5 sets `contain: layout` on the page container, which broke the fixed positioning of modals rendered inside it; modals are now moved to the top level of the page, as recommended by Bootstrap.
 - Fixed a regression introduced in v0.46 that could replace a variable with `NULL` while building a value that also used database expressions and `sqlpage.*` functions. For example, this API request could lose `john.doe` and produce a URL ending at `https://api.example.com/`:

--- a/examples/official-site/sqlpage/migrations/01_documentation.sql
+++ b/examples/official-site/sqlpage/migrations/01_documentation.sql
@@ -688,6 +688,7 @@ INSERT INTO parameter(component, name, description, type, top_level, optional) S
     ('label', 'An alias for parameter "x". On a row that draws a reference line, the text to display next to the line.', 'TEXT', FALSE, TRUE),
     ('value', 'An alias for parameter "y"', 'REAL', FALSE, TRUE),
     ('series', 'If multiple series are represented and share the same y-axis, this parameter can be used to distinguish between them.', 'TEXT', FALSE, TRUE),
+    ('link', 'Adds a clickable link to this point in its tooltip.', 'URL', FALSE, TRUE),
     ('yline', 'Draws a reference line across the chart at this value of the y axis instead of plotting a point, to show a limit such as a quota or an alarm threshold. Not drawn if it falls outside of the axis, so set ymax when the limit is above the data.', 'REAL', FALSE, TRUE),
     ('yline_end', 'Makes the yline a band instead of a line, reaching to this value.', 'REAL', FALSE, TRUE),
     ('xline', 'Draws a reference line across the chart at this position of the x axis instead of plotting a point, to mark an event such as a deployment. A date or a timestamp when time is set, otherwise one of the x values.', 'TEXT', FALSE, TRUE),
@@ -789,10 +790,10 @@ The `color` property sets the color of each series separately, in order.
         { "series": "PostgreSQL", "x": "2010", "y": 65},{ "series": "SQLite", "x": "2010", "y": 62},{ "series": "MySQL", "x": "2010", "y": 83},
         { "series": "PostgreSQL", "x": "2020", "y": 73},{ "series": "SQLite", "x": "2020", "y": 38},{ "series": "MySQL", "x": "2020", "y": 87}
       ]')),
-    ('chart', 'A timeline displaying events with a start and an end date',
+    ('chart', 'A timeline displaying events with a start and an end date. A data row can include a `link` to make it available as a clickable action in the tooltip.',
     json('[
         {"component":"chart", "title": "Project Timeline", "type": "rangeBar", "time": true, "color": ["teal", "cyan"], "labels": true, "xmin": "2021-12-28", "xmax": "2022-01-04" },
-        {"series": "Phase 1", "label": "Operations", "value": ["2021-12-29", "2022-01-02"]},
+        {"series": "Phase 1", "label": "Operations", "value": ["2021-12-29", "2022-01-02"], "link": "/examples/chart.sql?phase=1"},
         {"series": "Phase 2", "label": "Operations", "value": ["2022-01-03", "2022-01-04"]},
         {"series": "Yearly maintenance", "label": "Maintenance", "value": ["2022-01-01", "2022-01-03"]}
     ]')),

--- a/sqlpage/apexcharts.js
+++ b/sqlpage/apexcharts.js
@@ -405,9 +405,14 @@ sqlpage_chart = (() => {
 
   function chartTooltip({ seriesIndex, dataPointIndex, w }, raw_points) {
     const series = w.config.series[seriesIndex];
-    const name = series?.name || w.config.labels?.[dataPointIndex] || "";
-    const point = series?.data?.[dataPointIndex];
-    const link = series?.data ? point?.link : raw_points[dataPointIndex]?.[5];
+    const has_series_data = Array.isArray(series?.data);
+    const point_index = has_series_data ? dataPointIndex : seriesIndex;
+    const raw_point = raw_points[point_index];
+    const name = series?.name || w.config.labels?.[point_index] || "";
+    const point = has_series_data
+      ? series.data[dataPointIndex]
+      : { y: raw_point?.[2], z: raw_point?.[4] };
+    const link = has_series_data ? point?.link : raw_point?.[5];
 
     const tooltip = document.createElement("div");
     tooltip.className = "apexcharts-tooltip-text";

--- a/sqlpage/apexcharts.js
+++ b/sqlpage/apexcharts.js
@@ -442,7 +442,7 @@ sqlpage_chart = (() => {
       axisValue.appendChild(valueSpan);
       tooltip.appendChild(axisValue);
     }
-    add_link_to_tooltip(tooltip, link);
+    addLinkToTooltip(tooltip, link);
     return tooltip.outerHTML;
   }
 
@@ -451,7 +451,7 @@ sqlpage_chart = (() => {
   }
 
   /** @param {HTMLElement} tooltip @param {string|undefined} link */
-  function add_link_to_tooltip(tooltip, link) {
+  function addLinkToTooltip(tooltip, link) {
     if (!link) return;
     const linkContainer = document.createElement("div");
     linkContainer.className = "apexcharts-tooltip-y-group";

--- a/sqlpage/apexcharts.js
+++ b/sqlpage/apexcharts.js
@@ -406,9 +406,8 @@ sqlpage_chart = (() => {
   function chartTooltip({ seriesIndex, dataPointIndex, w }, raw_points) {
     const series = w.config.series[seriesIndex];
     const name = series?.name || w.config.labels?.[dataPointIndex] || "";
-    const point = series?.data?.[dataPointIndex] || {};
-    const link =
-      typeof point === "object" ? point.link : raw_points[dataPointIndex]?.[5];
+    const point = series?.data?.[dataPointIndex];
+    const link = series?.data ? point?.link : raw_points[dataPointIndex]?.[5];
 
     const tooltip = document.createElement("div");
     tooltip.className = "apexcharts-tooltip-text";

--- a/sqlpage/apexcharts.js
+++ b/sqlpage/apexcharts.js
@@ -434,7 +434,12 @@ sqlpage_chart = (() => {
       axisValue.appendChild(labelSpan);
       const valueSpan = document.createElement("span");
       valueSpan.className = "apexcharts-tooltip-text-y-value";
-      valueSpan.innerText = value;
+      const formatter = axis === "y" && w.config.tooltip.y.formatter;
+      const format = (v) =>
+        formatter ? formatter(v, { seriesIndex, dataPointIndex, w }) : v;
+      valueSpan.innerText = Array.isArray(value)
+        ? value.map(format).join(" - ")
+        : format(value);
       axisValue.appendChild(valueSpan);
       tooltip.appendChild(axisValue);
     }

--- a/sqlpage/apexcharts.js
+++ b/sqlpage/apexcharts.js
@@ -51,7 +51,7 @@ sqlpage_chart = (() => {
   };
 
   /** @typedef {number|string|Date} XValue */
-  /** @typedef { {x:XValue, y:number|null, z?:number, fillColor?:string} } ChartPoint */
+  /** @typedef { {x:XValue, y:number|null, z?:number, fillColor?:string, link?:string} } ChartPoint */
   /** @typedef { {name:string, data:ChartPoint[]} } ChartSeries */
   /** @typedef { { [name:string]: ChartSeries } } Series */
 
@@ -200,7 +200,7 @@ sqlpage_chart = (() => {
     const reference_rows = data.points.filter((row) => !Array.isArray(row));
     /** @type { Series } */
     const series_map = {};
-    for (const [name, old_x, old_y, color, z] of points) {
+    for (const [name, old_x, old_y, color, z, link] of points) {
       series_map[name] = series_map[name] || { name, data: [] };
       let x = old_x;
       let y = old_y;
@@ -210,7 +210,13 @@ sqlpage_chart = (() => {
           y = y.map((y) => new Date(y).getTime());
         else x = new Date(x);
       }
-      series_map[name].data.push({ x, y, z, fillColor: named_color(color) });
+      series_map[name].data.push({
+        x,
+        y,
+        z,
+        link,
+        fillColor: named_color(color),
+      });
     }
     if (data.xmin == null) data.xmin = undefined;
     if (data.xmax == null) data.xmax = undefined;
@@ -355,8 +361,9 @@ sqlpage_chart = (() => {
       },
       tooltip: {
         fillSeriesColor: false,
-        custom:
-          chart_type === "bubble" || chart_type === "scatter"
+        custom: points.some((point) => point[5])
+          ? (args) => chartTooltip(args, points)
+          : chart_type === "bubble" || chart_type === "scatter"
             ? bubbleTooltip
             : undefined,
         y: {
@@ -396,9 +403,11 @@ sqlpage_chart = (() => {
     c.removeAttribute("data-pre-init");
   }
 
-  function bubbleTooltip({ seriesIndex, dataPointIndex, w }) {
-    const { name, data } = w.config.series[seriesIndex];
-    const point = data[dataPointIndex];
+  function chartTooltip({ seriesIndex, dataPointIndex, w }, raw_points) {
+    const series = w.config.series[seriesIndex];
+    const name = series?.name || w.config.labels?.[dataPointIndex] || "";
+    const point = series?.data?.[dataPointIndex] || {};
+    const link = point.link || raw_points[dataPointIndex]?.[5];
 
     const tooltip = document.createElement("div");
     tooltip.className = "apexcharts-tooltip-text";
@@ -428,7 +437,24 @@ sqlpage_chart = (() => {
       axisValue.appendChild(valueSpan);
       tooltip.appendChild(axisValue);
     }
+    add_link_to_tooltip(tooltip, link);
     return tooltip.outerHTML;
+  }
+
+  function bubbleTooltip(args) {
+    return chartTooltip(args, []);
+  }
+
+  /** @param {HTMLElement} tooltip @param {string|undefined} link */
+  function add_link_to_tooltip(tooltip, link) {
+    if (!link) return;
+    const linkContainer = document.createElement("div");
+    linkContainer.className = "apexcharts-tooltip-y-group";
+    const anchor = document.createElement("a");
+    anchor.href = link;
+    anchor.textContent = "Open link";
+    linkContainer.appendChild(anchor);
+    tooltip.appendChild(linkContainer);
   }
 
   return sqlpage_chart;

--- a/sqlpage/apexcharts.js
+++ b/sqlpage/apexcharts.js
@@ -407,7 +407,8 @@ sqlpage_chart = (() => {
     const series = w.config.series[seriesIndex];
     const name = series?.name || w.config.labels?.[dataPointIndex] || "";
     const point = series?.data?.[dataPointIndex] || {};
-    const link = point.link || raw_points[dataPointIndex]?.[5];
+    const link =
+      typeof point === "object" ? point.link : raw_points[dataPointIndex]?.[5];
 
     const tooltip = document.createElement("div");
     tooltip.className = "apexcharts-tooltip-text";

--- a/sqlpage/sqlpage.css
+++ b/sqlpage/sqlpage.css
@@ -68,6 +68,11 @@ code {
   pointer-events: auto;
 }
 
+.apexcharts-tooltip a {
+  color: currentColor;
+  text-decoration: underline;
+}
+
 /** table **/
 .table-freeze-headers thead {
   position: sticky;

--- a/sqlpage/sqlpage.css
+++ b/sqlpage/sqlpage.css
@@ -64,6 +64,10 @@ code {
   color: inherit;
 }
 
+.apexcharts-tooltip:has(a) {
+  pointer-events: auto;
+}
+
 /** table **/
 .table-freeze-headers thead {
   position: sticky;

--- a/sqlpage/templates/chart.handlebars
+++ b/sqlpage/templates/chart.handlebars
@@ -51,8 +51,9 @@
             {{~ stringify (default series (default ../title "")) ~}},
             {{~ stringify (default x label) ~}},
             {{~ stringify (default y value) ~}}
-            {{~#if (or color z)}}, {{~ stringify color ~}} {{~/if~}}
-            {{~#if z}}, {{~ stringify z ~}} {{~/if~}}
+            {{~#if (or color z link)}}, {{~ stringify color ~}} {{~/if~}}
+            {{~#if (or z link)}}, {{~ stringify z ~}} {{~/if~}}
+            {{~#if link}}, {{~ stringify link ~}} {{~/if~}}
         ]
         {{~/if~}}
     {{~/each_row~}}

--- a/tests/components/chart_point_serialization.sql
+++ b/tests/components/chart_point_serialization.sql
@@ -1,7 +1,0 @@
-SELECT 'chart' AS component, 'It works !' AS title;
-SELECT 'plain' AS x, '1' AS y;
-SELECT 'colored' AS x, '2' AS y, 'red' AS color;
-SELECT 'sized' AS x, '3' AS y, '30' AS z;
-SELECT 'both' AS x, '4' AS y, 'green' AS color, '40' AS z;
-SELECT 'linked' AS x, '5' AS y, '/edit.sql?id=5' AS link;
-SELECT '70' AS yline, 'limit' AS label, 'orange' AS color;

--- a/tests/components/chart_point_serialization.sql
+++ b/tests/components/chart_point_serialization.sql
@@ -3,4 +3,5 @@ SELECT 'plain' AS x, '1' AS y;
 SELECT 'colored' AS x, '2' AS y, 'red' AS color;
 SELECT 'sized' AS x, '3' AS y, '30' AS z;
 SELECT 'both' AS x, '4' AS y, 'green' AS color, '40' AS z;
+SELECT 'linked' AS x, '5' AS y, '/edit.sql?id=5' AS link;
 SELECT '70' AS yline, 'limit' AS label, 'orange' AS color;

--- a/tests/end-to-end/fixtures/chart/link-bar.sql
+++ b/tests/end-to-end/fixtures/chart/link-bar.sql
@@ -1,0 +1,4 @@
+SELECT 'chart' AS component, 'test-chart' AS id, 'Chart test fixture' AS title,
+    'bar' AS type;
+SELECT 'Points' AS series, 'Linked' AS label, 10 AS value, '/linked.sql' AS link;
+SELECT 'Points' AS series, 'Linked too' AS label, 20 AS value, '/linked-too.sql' AS link;

--- a/tests/end-to-end/fixtures/chart/link-line.sql
+++ b/tests/end-to-end/fixtures/chart/link-line.sql
@@ -1,0 +1,4 @@
+SELECT 'chart' AS component, 'test-chart' AS id, 'Chart test fixture' AS title,
+    'line' AS type, 8 AS marker;
+SELECT 'Points' AS series, 1 AS x, 10 AS y, '/linked.sql' AS link;
+SELECT 'Points' AS series, 2 AS x, 20 AS y, '/linked-too.sql' AS link;

--- a/tests/end-to-end/fixtures/chart/link-pie.sql
+++ b/tests/end-to-end/fixtures/chart/link-pie.sql
@@ -1,0 +1,4 @@
+SELECT 'chart' AS component, 'test-chart' AS id, 'Chart test fixture' AS title,
+    'pie' AS type;
+SELECT 'Points' AS series, 'A' AS label, 10 AS value, '/linked.sql' AS link;
+SELECT 'Points' AS series, 'B' AS label, 20 AS value, '/linked-too.sql' AS link;

--- a/tests/end-to-end/fixtures/chart/link-scatter.sql
+++ b/tests/end-to-end/fixtures/chart/link-scatter.sql
@@ -1,0 +1,4 @@
+SELECT 'chart' AS component, 'test-chart' AS id, 'Chart test fixture' AS title,
+    'scatter' AS type, 8 AS marker;
+SELECT 'Points' AS series, 1 AS x, 1 AS y, '/linked.sql' AS link;
+SELECT 'Points' AS series, 2 AS x, 2 AS y, '/linked-too.sql' AS link;

--- a/tests/end-to-end/fixtures/chart/link.sql
+++ b/tests/end-to-end/fixtures/chart/link.sql
@@ -1,0 +1,5 @@
+SELECT 'chart' AS component, 'test-chart' AS id, 'Chart test fixture' AS title,
+    'rangeBar' AS type, TRUE AS time;
+SELECT 'Design' AS series, 'Alice' AS label,
+    '2024-03-01' AS value, '2024-03-05' AS value,
+    '/workpackage_edit.sql?workpackage_name=Design' AS link;

--- a/tests/end-to-end/fixtures/chart/link.sql
+++ b/tests/end-to-end/fixtures/chart/link.sql
@@ -3,3 +3,5 @@ SELECT 'chart' AS component, 'test-chart' AS id, 'Chart test fixture' AS title,
 SELECT 'Design' AS series, 'Alice' AS label,
     '2024-03-01' AS value, '2024-03-05' AS value,
     '/workpackage_edit.sql?workpackage_name=Design' AS link;
+SELECT 'Research' AS series, 'Bob' AS label,
+    '2024-03-06' AS value, '2024-03-10' AS value;

--- a/tests/end-to-end/fixtures/chart/test.ts
+++ b/tests/end-to-end/fixtures/chart/test.ts
@@ -417,6 +417,18 @@ for (const [type, mark] of [
   });
 }
 
+test("links each slice of a pie chart from its own row", async ({ page }) => {
+  const chart = await renderChart(page, "link-pie");
+
+  expect(chart.failures).toEqual([]);
+  const slices = page.locator("#test-chart .apexcharts-pie-area");
+  const link = page.locator("#test-chart .apexcharts-tooltip a");
+  await slices.nth(0).hover();
+  await expect(link).toHaveAttribute("href", "/linked.sql");
+  await slices.nth(1).hover();
+  await expect(link).toHaveAttribute("href", "/linked-too.sql");
+});
+
 test("formats date ranges in a linked tooltip", async ({ page }) => {
   await renderChart(page, "link");
 

--- a/tests/end-to-end/fixtures/chart/test.ts
+++ b/tests/end-to-end/fixtures/chart/test.ts
@@ -367,6 +367,18 @@ test("leaves a rangeBar chart on a category axis alone", async ({ page }) => {
   expect(chart.shapes).toHaveLength(2);
 });
 
+test("shows a data point link in its tooltip", async ({ page }) => {
+  await renderChart(page, "link");
+
+  await page.locator("#test-chart .apexcharts-rangebar-area").hover();
+  const link = page.locator("#test-chart .apexcharts-tooltip a");
+  await expect(link).toHaveText("Open link");
+  await expect(link).toHaveAttribute(
+    "href",
+    "/workpackage_edit.sql?workpackage_name=Design",
+  );
+});
+
 test("leaves a treemap chart alone", async ({ page }) => {
   const chart = await renderChart(page, "treemap");
 

--- a/tests/end-to-end/fixtures/chart/test.ts
+++ b/tests/end-to-end/fixtures/chart/test.ts
@@ -383,6 +383,15 @@ test("shows an interactive data point link in a rangeBar tooltip", async ({
     "pointer-events",
     "auto",
   );
+  const colors = await link.evaluate((anchor) => {
+    const tooltip = anchor.closest(".apexcharts-tooltip");
+    if (!tooltip) throw new Error("Link has no tooltip");
+    return {
+      link: getComputedStyle(anchor).color,
+      tooltip: getComputedStyle(tooltip).color,
+    };
+  });
+  expect(colors.link).toBe(colors.tooltip);
   await page.locator("#test-chart .apexcharts-rangebar-area").nth(1).hover();
   await expect(page.locator("#test-chart .apexcharts-tooltip a")).toHaveCount(
     0,
@@ -392,7 +401,11 @@ test("shows an interactive data point link in a rangeBar tooltip", async ({
   await expect(page).toHaveURL(/workpackage_edit/);
 });
 
-for (const [type, mark] of [["scatter", ".apexcharts-marker"]]) {
+for (const [type, mark] of [
+  ["bar", ".apexcharts-bar-area"],
+  ["line", ".apexcharts-marker"],
+  ["scatter", ".apexcharts-marker"],
+]) {
   test(`shows a data point link in a ${type} tooltip`, async ({ page }) => {
     await renderChart(page, `link-${type}`);
 

--- a/tests/end-to-end/fixtures/chart/test.ts
+++ b/tests/end-to-end/fixtures/chart/test.ts
@@ -367,16 +367,50 @@ test("leaves a rangeBar chart on a category axis alone", async ({ page }) => {
   expect(chart.shapes).toHaveLength(2);
 });
 
-test("shows a data point link in its tooltip", async ({ page }) => {
+test("shows an interactive data point link in a rangeBar tooltip", async ({
+  page,
+}) => {
   await renderChart(page, "link");
 
-  await page.locator("#test-chart .apexcharts-rangebar-area").hover();
+  await page.locator("#test-chart .apexcharts-rangebar-area").first().hover();
   const link = page.locator("#test-chart .apexcharts-tooltip a");
   await expect(link).toHaveText("Open link");
   await expect(link).toHaveAttribute(
     "href",
     "/workpackage_edit.sql?workpackage_name=Design",
   );
+  await expect(page.locator("#test-chart .apexcharts-tooltip")).toHaveCSS(
+    "pointer-events",
+    "auto",
+  );
+  await page.locator("#test-chart .apexcharts-rangebar-area").nth(1).hover();
+  await expect(page.locator("#test-chart .apexcharts-tooltip a")).toHaveCount(
+    0,
+  );
+  await page.locator("#test-chart .apexcharts-rangebar-area").first().hover();
+  await link.click();
+  await expect(page).toHaveURL(/workpackage_edit/);
+});
+
+for (const [type, mark] of [["scatter", ".apexcharts-marker"]]) {
+  test(`shows a data point link in a ${type} tooltip`, async ({ page }) => {
+    await renderChart(page, `link-${type}`);
+
+    const marks = page.locator(`#test-chart ${mark}`);
+    await marks.nth(0).hover({ force: true });
+    await expect(page.locator("#test-chart .apexcharts-tooltip a")).toHaveCount(
+      1,
+    );
+  });
+}
+
+test("formats date ranges in a linked tooltip", async ({ page }) => {
+  await renderChart(page, "link");
+
+  await page.locator("#test-chart .apexcharts-rangebar-area").first().hover();
+  await expect(
+    page.locator("#test-chart .apexcharts-tooltip"),
+  ).not.toContainText("1709251200000");
 });
 
 test("leaves a treemap chart alone", async ({ page }) => {


### PR DESCRIPTION
## Summary

Closes #945.

Adds an optional row-level `link` parameter to the `chart` component. When a chart data row has a link, the chart tooltip includes an accessible `Open link` anchor pointing to that URL.

## Implementation

- Carries `link` through the chart template's point data without changing the existing color/z positions.
- Preserves links on aligned series points.
- Uses a small DOM-based tooltip renderer only for charts that contain links; charts without links keep ApexCharts' existing tooltip behavior.
- Handles range bars and other point-based charts, including pie-series data stored by ApexCharts as scalar values.
- Documents the parameter and adds a timeline example.

## Tests

- `npm test`
- `cargo test`
- `cd tests/end-to-end && npm run test -- --grep "data point link"`
